### PR TITLE
feat: publish as npm package for OpenCode compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.10.3"
+    "version": "1.10.4"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.10.4 (2026-08-01)
+
+Publish as an npm package for OpenCode compatibility (originally PR #4). Adds
+`package.json` and an `index.js` programmatic API (`listSkills`, `getSkill`,
+`readSkill`, `listPlugins`, `getPluginSkills`, etc.) so agents/tools can
+consume skills without a Claude Code-specific install path.
+
+The original PR hardcoded the skill list (3 of the then-current 7 skills)
+and invented a two-bundle plugin structure that didn't match
+`.claude-plugin/marketplace.json`'s actual single `freenet` bundle. Both had
+already gone stale by review time. Rewrote `index.js` to discover skills
+from the `skills/` directory and plugin bundles from
+`.claude-plugin/marketplace.json` at require-time instead of hardcoding
+either, so this can't drift out of sync again. Updated README's Available
+Skills, OpenCode install, Repository Structure, and Programmatic API
+sections to match the current 7-skill lineup.
+
+Review also found: `package.json`'s `files` field omitted `.claude-plugin/`
+(so a real npm install would ship without `marketplace.json` and
+`listPlugins()`/`getPluginSkills()` would silently return empty — fixed),
+and `readReference()` had no path-containment check (fixed). Skill/plugin
+maps now use `Object.create(null)` so a `__proto__` lookup returns `null`
+instead of `Object.prototype`.
+
 ## 1.10.3 (2026-08-01)
 
 Add a strong recommendation to keep contract state small. `dapp-builder`
@@ -18,9 +42,9 @@ directly as load latency, and WASM execution cost scales with it too.
 - `references/state-authorization-patterns.md`: new "Design target: stay
   well under 4 MB per instance" paragraph in the State Size Budget
   section, distinguishing the correctness backstop (50 MiB) from the UX
-  design target (4 MB). Notes that the existing inbox example (~32 MiB
-  worst case) is already sharded to the finest reasonable granularity —
-  per recipient — so it's a deliberate ceiling, not a counterexample.
+  design target (4 MB). The existing inbox example (~32 MiB worst case)
+  is reframed as a bound the new target argues for revisiting, not one
+  that's already settled.
 
 ## 1.10.2 (2026-07-30)
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ Methodology for debugging non-trivial problems:
 - Anti-patterns to avoid (jumping to conclusions, weakening tests)
 - Test coverage gap analysis
 
+### [pr-review](./skills/pr-review/)
+
+Risk-tiered, multi-perspective PR review — triages the change, runs specialist subagents in
+parallel (code-first, testing, skeptical, big-picture), plus an external model pass scaled to
+risk, then posts a consolidated review to the PR.
+
+### [release](./skills/release/)
+
+Orchestrates a Freenet release: determines the next version, shows the changelog, confirms with
+the user, and triggers the release pipeline via GitHub Actions.
+
+### [linux-test](./skills/linux-test/)
+
+Runs integration tests that require Linux's full loopback range via Docker — for tests that fail
+on macOS with "Can't assign requested address".
+
+### [local-dev](./skills/local-dev/)
+
+Set up and manage local Freenet development environments: run a local node, publish contracts,
+query connections/diagnostics, and iterate on a Freenet application without deploying to the live
+network.
+
 ## Hooks
 
 The [`hooks/`](./hooks/) directory contains two types of hooks for Freenet development:
@@ -87,13 +109,37 @@ ln -s ~/freenet-agent-skills/skills/dapp-builder ~/.claude/skills/
 
 ### OpenCode
 
+**Option 1: npm (Recommended)**
+```bash
+npm install freenet-agent-skills
+```
+
+Then symlink the skills you want to the skills directory (see [Available Skills](#available-skills)
+above for the full list), e.g.:
+```bash
+ln -s node_modules/freenet-agent-skills/skills/dapp-builder ~/.claude/skills/
+ln -s node_modules/freenet-agent-skills/skills/pr-creation ~/.claude/skills/
+```
+
+Or symlink all of them programmatically:
+```bash
+node -e "require('freenet-agent-skills').listSkills().forEach(s => \
+  console.log(require('freenet-agent-skills').getSkill(s).path))"
+```
+
+**Option 2: openskills**
+```bash
+openskills install freenet/freenet-agent-skills
+```
+
+**Option 3: Git clone**
+
 OpenCode automatically discovers skills from Claude-compatible paths:
 
 ```bash
 git clone https://github.com/freenet/freenet-agent-skills.git ~/freenet-agent-skills
 ln -s ~/freenet-agent-skills/skills/dapp-builder ~/.claude/skills/
 ln -s ~/freenet-agent-skills/skills/pr-creation ~/.claude/skills/
-ln -s ~/freenet-agent-skills/skills/systematic-debugging ~/.claude/skills/
 ```
 
 ### Project-specific Installation
@@ -120,15 +166,26 @@ freenet-agent-skills/
 │   │   ├── SKILL.md       # Main skill definition
 │   │   ├── README.md      # Skill documentation
 │   │   └── references/    # Detailed documentation
+│   ├── linux-test/
+│   │   └── SKILL.md
+│   ├── local-dev/
+│   │   └── SKILL.md
 │   ├── pr-creation/
 │   │   └── SKILL.md
+│   ├── pr-review/
+│   │   └── SKILL.md
+│   ├── release/
+│   │   └── SKILL.md
 │   └── systematic-debugging/
-│       └── SKILL.md
+│       ├── SKILL.md
+│       └── references/
 ├── hooks/
 │   ├── hooks.json         # Claude Code hooks (run before git commit)
 │   ├── pre-commit         # Git pre-commit hook for cargo fmt/clippy
 │   └── README.md
 ├── agents/                # Subagent definitions (reviewers, etc.)
+├── index.js               # OpenCode plugin entry point / npm programmatic API
+├── package.json           # npm package manifest
 ├── README.md
 └── LICENSE
 ```
@@ -140,6 +197,33 @@ See [CLAUDE.md](./CLAUDE.md) for the current version and version history. When m
 1. Update `.claude-plugin/marketplace.json` → `metadata.version`
 2. Update `CLAUDE.md` with version number and changelog entry
 3. Commit both files together
+
+## Programmatic API (npm)
+
+When installed via npm, the package exports functions for programmatic access. `listSkills()` and
+`listPlugins()` are derived from the `skills/` directory and `.claude-plugin/marketplace.json` at
+require-time, so they always reflect what's actually in the repo:
+
+```javascript
+const skills = require('freenet-agent-skills');
+
+// List available skills (reads skills/ on require, not a hardcoded list)
+skills.listSkills(); // ['dapp-builder', 'linux-test', 'local-dev', 'pr-creation', 'pr-review', 'release', 'systematic-debugging']
+
+// Get skill metadata
+skills.getSkill('dapp-builder');
+
+// Read skill content
+const content = skills.readSkill('dapp-builder');
+
+// Get paths for integration
+skills.getSkillsPath();       // Absolute path to skills directory
+skills.getSkillPath('dapp-builder');  // Path to SKILL.md
+
+// Work with plugin bundles (reads .claude-plugin/marketplace.json)
+skills.listPlugins();  // ['freenet']
+skills.getPluginSkills('freenet');  // All skill metadata objects in the plugin
+```
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,247 @@
+/**
+ * freenet-agent-skills
+ *
+ * AI coding agent skills for building applications on Freenet.
+ * Compatible with Claude Code and OpenCode.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SKILLS_DIR = path.join(__dirname, 'skills');
+const MARKETPLACE_PATH = path.join(__dirname, '.claude-plugin', 'marketplace.json');
+
+/**
+ * Plugin metadata
+ */
+const metadata = {
+  name: 'freenet-agent-skills',
+  description: 'AI coding agent skills for Freenet development',
+  version: require('./package.json').version,
+  author: 'Freenet Project',
+  license: 'LGPL-3.0'
+};
+
+/**
+ * Parse the YAML frontmatter of a SKILL.md file. Frontmatter here is always
+ * flat `key: value` pairs, so a hand-rolled parser avoids taking on a YAML
+ * dependency for this one use.
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const frontmatter = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    let value = line.slice(separator + 1).trim();
+    if (value === 'true') value = true;
+    else if (value === 'false') value = false;
+    frontmatter[key] = value;
+  }
+  return frontmatter;
+}
+
+/**
+ * Discover skills from the skills/ directory. This reads the filesystem at
+ * require-time rather than hardcoding a skill list — a hardcoded list goes
+ * stale the moment a skill is added, renamed, or removed (see repo history:
+ * this is what made the original version of this file wrong within weeks).
+ */
+function discoverSkills() {
+  const result = {};
+  if (!fs.existsSync(SKILLS_DIR)) return result;
+
+  const entries = fs
+    .readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const skillPath = path.join(SKILLS_DIR, entry.name);
+    const skillFile = path.join(skillPath, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) continue;
+
+    const frontmatter = parseFrontmatter(fs.readFileSync(skillFile, 'utf8'));
+    const referencesDir = path.join(skillPath, 'references');
+    const references = fs.existsSync(referencesDir)
+      ? fs
+          .readdirSync(referencesDir)
+          .filter((f) => f.endsWith('.md'))
+          .sort()
+          .map((f) => path.join('references', f))
+      : [];
+
+    result[entry.name] = {
+      name: frontmatter.name || entry.name,
+      description: frontmatter.description || '',
+      path: skillPath,
+      skillFile: 'SKILL.md',
+      references
+    };
+  }
+  return result;
+}
+
+/**
+ * Discover plugin bundles from the marketplace manifest — the same file
+ * Claude Code reads to install skills — rather than re-describing the
+ * bundle structure here where it can drift out of sync.
+ */
+function discoverPlugins() {
+  const result = {};
+  if (!fs.existsSync(MARKETPLACE_PATH)) return result;
+
+  const manifest = JSON.parse(fs.readFileSync(MARKETPLACE_PATH, 'utf8'));
+  for (const plugin of manifest.plugins || []) {
+    result[plugin.name] = {
+      name: plugin.name,
+      description: plugin.description,
+      skills: (plugin.skills || []).map((skillPath) => path.basename(skillPath))
+    };
+  }
+  return result;
+}
+
+const skills = discoverSkills();
+const plugins = discoverPlugins();
+
+/**
+ * Get the path to the skills directory
+ * @returns {string} Absolute path to skills directory
+ */
+function getSkillsPath() {
+  return SKILLS_DIR;
+}
+
+/**
+ * List all available skills
+ * @returns {string[]} Array of skill names
+ */
+function listSkills() {
+  return Object.keys(skills);
+}
+
+/**
+ * Get skill metadata
+ * @param {string} skillName - Name of the skill
+ * @returns {object|null} Skill metadata or null if not found
+ */
+function getSkill(skillName) {
+  return skills[skillName] || null;
+}
+
+/**
+ * Get the full path to a skill's SKILL.md file
+ * @param {string} skillName - Name of the skill
+ * @returns {string|null} Absolute path to SKILL.md or null if not found
+ */
+function getSkillPath(skillName) {
+  const skill = skills[skillName];
+  if (!skill) return null;
+  return path.join(skill.path, skill.skillFile);
+}
+
+/**
+ * Read a skill's SKILL.md content
+ * @param {string} skillName - Name of the skill
+ * @returns {string|null} Content of SKILL.md or null if not found
+ */
+function readSkill(skillName) {
+  const skillPath = getSkillPath(skillName);
+  if (!skillPath) return null;
+
+  try {
+    return fs.readFileSync(skillPath, 'utf8');
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Get all reference file paths for a skill
+ * @param {string} skillName - Name of the skill
+ * @returns {string[]} Array of absolute paths to reference files
+ */
+function getReferencePaths(skillName) {
+  const skill = skills[skillName];
+  if (!skill) return [];
+
+  return skill.references.map((ref) => path.join(skill.path, ref));
+}
+
+/**
+ * Read a specific reference file
+ * @param {string} skillName - Name of the skill
+ * @param {string} referenceName - Name of the reference file (e.g., 'contract-patterns.md')
+ * @returns {string|null} Content of the reference file or null if not found
+ */
+function readReference(skillName, referenceName) {
+  const skill = skills[skillName];
+  if (!skill) return null;
+
+  const refPath = path.join(skill.path, 'references', referenceName);
+
+  try {
+    return fs.readFileSync(refPath, 'utf8');
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * List available plugins
+ * @returns {string[]} Array of plugin names
+ */
+function listPlugins() {
+  return Object.keys(plugins);
+}
+
+/**
+ * Get plugin metadata
+ * @param {string} pluginName - Name of the plugin
+ * @returns {object|null} Plugin metadata or null if not found
+ */
+function getPlugin(pluginName) {
+  return plugins[pluginName] || null;
+}
+
+/**
+ * Get all skills in a plugin
+ * @param {string} pluginName - Name of the plugin
+ * @returns {object[]} Array of skill metadata objects
+ */
+function getPluginSkills(pluginName) {
+  const plugin = plugins[pluginName];
+  if (!plugin) return [];
+
+  return plugin.skills.map((name) => skills[name]).filter(Boolean);
+}
+
+module.exports = {
+  // Metadata
+  metadata,
+  skills,
+  plugins,
+
+  // Path functions
+  getSkillsPath,
+  getSkillPath,
+  getReferencePaths,
+
+  // Listing functions
+  listSkills,
+  listPlugins,
+
+  // Getter functions
+  getSkill,
+  getPlugin,
+  getPluginSkills,
+
+  // Reader functions
+  readSkill,
+  readReference
+};

--- a/index.js
+++ b/index.js
@@ -51,7 +51,9 @@ function parseFrontmatter(content) {
  * this is what made the original version of this file wrong within weeks).
  */
 function discoverSkills() {
-  const result = {};
+  // Object.create(null): a plain {} would let a lookup like skills['__proto__']
+  // resolve to Object.prototype instead of undefined.
+  const result = Object.create(null);
   if (!fs.existsSync(SKILLS_DIR)) return result;
 
   const entries = fs
@@ -92,7 +94,7 @@ function discoverSkills() {
  * bundle structure here where it can drift out of sync.
  */
 function discoverPlugins() {
-  const result = {};
+  const result = Object.create(null);
   if (!fs.existsSync(MARKETPLACE_PATH)) return result;
 
   const manifest = JSON.parse(fs.readFileSync(MARKETPLACE_PATH, 'utf8'));
@@ -183,7 +185,13 @@ function readReference(skillName, referenceName) {
   const skill = skills[skillName];
   if (!skill) return null;
 
-  const refPath = path.join(skill.path, 'references', referenceName);
+  const referencesDir = path.join(skill.path, 'references');
+  const refPath = path.join(referencesDir, referenceName);
+
+  // referenceName may come from untrusted/LLM-constructed input; reject any
+  // path that escapes the skill's references/ directory (e.g. '../../../etc/passwd').
+  const relative = path.relative(referencesDir, refPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
 
   try {
     return fs.readFileSync(refPath, 'utf8');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "freenet-agent-skills",
+  "version": "1.0.0",
+  "description": "AI coding agent skills for building applications on Freenet. Compatible with Claude Code and OpenCode.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/freenet/freenet-agent-skills.git"
+  },
+  "keywords": [
+    "freenet",
+    "ai",
+    "agent",
+    "skills",
+    "claude",
+    "opencode",
+    "decentralized",
+    "dapp",
+    "blockchain"
+  ],
+  "author": "Freenet Project <support@freenet.org>",
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/freenet/freenet-agent-skills/issues"
+  },
+  "homepage": "https://github.com/freenet/freenet-agent-skills#readme",
+  "files": [
+    "index.js",
+    "skills/"
+  ],
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/freenet/freenet-agent-skills#readme",
   "files": [
     "index.js",
-    "skills/"
+    "skills/",
+    ".claude-plugin/"
   ],
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Add npm package support to enable seamless integration across both
Claude Code and OpenCode platforms:

- Add package.json with npm metadata and keywords for discoverability
- Create index.js as OpenCode plugin entry point with programmatic API
- Update README with npm installation instructions and API documentation

Closes #3