### PR TITLE
docs: fix /plugin install commands in READMEs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.0.16"
+    "version": "1.0.17"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.17 (2026-05-06)
+- Fixed install instructions in `README.md` and `skills/dapp-builder/README.md`:
+  the marketplace exposes a single bundled plugin named `freenet`, but the
+  READMEs told users to run `/plugin install freenet-dapp-builder` and
+  `/plugin install freenet-core-dev` (neither exists). Replaced with the
+  correct `/plugin install freenet@freenet-agent-skills` form.
+
 ## 1.0.16 (2026-04-29)
 - Fixed release skill: documented the new tiered merge_group model
   (freenet/freenet-core#3973). Release merge_group entries now run the FULL

--- a/README.md
+++ b/README.md
@@ -63,17 +63,13 @@ Add the marketplace:
 /plugin marketplace add freenet/freenet-agent-skills
 ```
 
-Then install the plugin you need:
+Then install the plugin:
 
 ```bash
-# For building apps on Freenet
-/plugin install freenet-dapp-builder
-
-# For contributing to Freenet core
-/plugin install freenet-core-dev
+/plugin install freenet@freenet-agent-skills
 ```
 
-Or browse available plugins via `/plugin` → **Discover** tab.
+This installs all bundled skills (dapp-builder, pr-creation, pr-review, release, systematic-debugging, linux-test, local-dev). Browse via `/plugin` → **Discover** tab to confirm.
 
 ### Manual Installation
 

--- a/skills/dapp-builder/README.md
+++ b/skills/dapp-builder/README.md
@@ -16,8 +16,10 @@ Guides you through building decentralized apps following the architecture patter
 
 ```bash
 /plugin marketplace add freenet/freenet-agent-skills
-/plugin install freenet-dapp-builder
+/plugin install freenet@freenet-agent-skills
 ```
+
+The dapp-builder skill is bundled inside the `freenet` plugin along with the other Freenet skills.
 
 ### Manual Installation
 


### PR DESCRIPTION
## Problem

A user following the dapp-builder install instructions hit:

```
/plugin install freenet-dapp-builder
└ Plugin 'freenet-dapp-builder' not found in any marketplace
```

The READMEs reference non-existent plugins (`freenet-dapp-builder`, `freenet-core-dev`). The marketplace at `.claude-plugin/marketplace.json` defines a single plugin named `freenet` that bundles every skill in this repo, so the documented install commands cannot work.

## Approach

Update both READMEs (`README.md` and `skills/dapp-builder/README.md`) to use the correct form:

```
/plugin install freenet@freenet-agent-skills
```

…and note that the dapp-builder skill ships as part of the bundled `freenet` plugin. `hooks/README.md` was already correct.

## Testing

- Confirmed `marketplace.json` exposes a single `freenet` plugin (no `freenet-dapp-builder` / `freenet-core-dev`).
- Confirmed `/plugin install <plugin>@<marketplace>` is the canonical Claude Code form.

[AI-assisted - Claude]