### PR TITLE
feat(pr-review): risk-tiered multi-agent PR review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.0.19"
+    "version": "1.1.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.0 (2026-05-20)
+- Reworked `pr-review` to match current Claude Code capabilities and PR-review
+  best practices:
+  - **Parallel subagents are now the default path**, not an optional addendum.
+    The skill orchestrates the four reviewers concurrently rather than walking
+    one agent through six perspectives by hand.
+  - **Invokes the reviewers as first-class subagents** (`freenet:code-first-reviewer`,
+    `freenet:testing-reviewer`, `freenet:skeptical-reviewer`,
+    `freenet:big-picture-reviewer`) via the `Agent` tool's `subagent_type` with
+    `run_in_background: true`. Removed the obsolete "spawn `general-purpose` and
+    paste the agent definition into the prompt" instructions.
+  - **Checks out the PR branch** (`gh pr checkout`) before spawning reviewers, so
+    their `Read`/`Grep` calls see the PR's code instead of `main`'s. Added
+    checkout-awareness notes to all four agent definitions.
+  - **Fetches existing PR review comments** up front (issue-level and inline) so
+    the review addresses prior feedback instead of duplicating it; cross-refs the
+    `gh-pr-interactions` skill.
+  - **Added a synthesis step**: deduplicate overlapping findings, reconcile
+    reviewer disagreements, and verify every cited `file:line` before reporting.
+  - **Posts the consolidated review to the PR** via `gh pr review --comment`.
+  - References the `codex-review` / `gemini-cli-review` skills for the external
+    model pass instead of a vague "ask Codex" instruction.
+  - De-staled the Freenet bug-pattern guidance: SKILL.md and the skeptical/testing
+    agents now point at the canonical, continuously-updated
+    `.claude/rules/bug-prevention-patterns.md` in freenet-core and no longer claim
+    the frozen Feb-2025 snapshot of five patterns is complete.
+  - Added large-diff (file-batching) guidance and a branch-cleanup reminder.
+
 ## 1.0.19 (2026-05-06)
 - Reordered concepts in `dapp-builder/SKILL.md`: the "Core Concept: The
   Contract is the Key" section used to come before the components were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ## 1.1.0 (2026-05-20)
 - Reworked `pr-review` to match current Claude Code capabilities and PR-review
   best practices:
+  - **Risk-tiered review.** The skill triages each PR to Skip / Light / Full and
+    scales the reviewer set to match — trivial changes are not put through the full
+    multi-model treatment; high-risk surfaces (concurrency, crypto, migrations, wire
+    format, transport, contract/delegate WASM) always get the full review.
   - **Parallel subagents are now the default path**, not an optional addendum.
     The skill orchestrates the four reviewers concurrently rather than walking
     one agent through six perspectives by hand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,22 +17,23 @@ All notable changes to this project will be documented in this file.
     `freenet:big-picture-reviewer`) via the `Agent` tool's `subagent_type` with
     `run_in_background: true`. Removed the obsolete "spawn `general-purpose` and
     paste the agent definition into the prompt" instructions.
-  - **Checks out the PR branch** (`gh pr checkout`) before spawning reviewers, so
-    their `Read`/`Grep` calls see the PR's code instead of `main`'s. Added
-    checkout-awareness notes to all four agent definitions.
+  - **Reviews from a dedicated worktree** of the PR's code, so reviewers `Read`/`Grep`
+    the PR's actual code (not `main`'s) without disturbing the user's working tree —
+    avoids `gh pr checkout` clobbering uncommitted work. Added checkout-awareness
+    notes to all four agent definitions.
   - **Fetches existing PR review comments** up front (issue-level and inline) so
-    the review addresses prior feedback instead of duplicating it; cross-refs the
-    `gh-pr-interactions` skill.
+    the review addresses prior feedback instead of duplicating it.
   - **Added a synthesis step**: deduplicate overlapping findings, reconcile
     reviewer disagreements, and verify every cited `file:line` before reporting.
   - **Posts the consolidated review to the PR** via `gh pr review --comment`.
-  - References the `codex-review` / `gemini-cli-review` skills for the external
-    model pass instead of a vague "ask Codex" instruction.
+  - Replaced the vague "ask Codex" instruction with a concrete external-model pass
+    (`codex review`), optionally wrapped by a `codex-review` / `gemini-cli-review`
+    skill when the environment provides one.
   - De-staled the Freenet bug-pattern guidance: SKILL.md and the skeptical/testing
     agents now point at the canonical, continuously-updated
     `.claude/rules/bug-prevention-patterns.md` in freenet-core and no longer claim
     the frozen Feb-2025 snapshot of five patterns is complete.
-  - Added large-diff (file-batching) guidance and a branch-cleanup reminder.
+  - Added large-diff (file-batching) guidance and a mandatory worktree-cleanup step.
 
 ## 1.0.19 (2026-05-06)
 - Reordered concepts in `dapp-builder/SKILL.md`: the "Core Concept: The

--- a/agents/big-picture-reviewer.md
+++ b/agents/big-picture-reviewer.md
@@ -53,6 +53,9 @@ gh pr diff <NUMBER>
 git log --oneline -20 -- <affected-files>
 ```
 
+The PR branch is checked out locally — `Read`/`Grep` the affected files at the PR's
+version when you need more context than the diff provides.
+
 Red flags:
 - **Removed tests** - especially tests added to catch specific bugs
 - **Removed fix code** - not just tests, but actual fixes

--- a/agents/big-picture-reviewer.md
+++ b/agents/big-picture-reviewer.md
@@ -53,8 +53,9 @@ gh pr diff <NUMBER>
 git log --oneline -20 -- <affected-files>
 ```
 
-The PR branch is checked out locally — `Read`/`Grep` the affected files at the PR's
-version when you need more context than the diff provides.
+The orchestrator's prompt gives you the absolute path to a worktree containing the
+PR's code — `Read`/`Grep` the affected files there when you need more context than
+the diff provides.
 
 Red flags:
 - **Removed tests** - especially tests added to catch specific bugs

--- a/agents/code-first-reviewer.md
+++ b/agents/code-first-reviewer.md
@@ -18,9 +18,9 @@ Review a PR using the code-first methodology to catch discrepancies between what
 
 Read ONLY the code changes using `gh pr diff <NUMBER>`. Do NOT read the PR description or comments yet.
 
-The PR branch is checked out locally, so you may also `Read`/`Grep` the surrounding
-code at the PR's version for context — just don't open the PR description or comments
-until Step 2.
+The orchestrator's prompt gives you the absolute path to a worktree containing the
+PR's code. You may `Read`/`Grep` the surrounding code there for context — just don't
+open the PR description or comments until Step 2.
 
 Form your own understanding of:
 - What the code actually does

--- a/agents/code-first-reviewer.md
+++ b/agents/code-first-reviewer.md
@@ -18,6 +18,10 @@ Review a PR using the code-first methodology to catch discrepancies between what
 
 Read ONLY the code changes using `gh pr diff <NUMBER>`. Do NOT read the PR description or comments yet.
 
+The PR branch is checked out locally, so you may also `Read`/`Grep` the surrounding
+code at the PR's version for context — just don't open the PR description or comments
+until Step 2.
+
 Form your own understanding of:
 - What the code actually does
 - What problem it appears to solve

--- a/agents/skeptical-reviewer.md
+++ b/agents/skeptical-reviewer.md
@@ -123,8 +123,8 @@ authoritative. Actively check for these, plus whatever else the canonical file l
 # Get the diff
 gh pr diff <NUMBER>
 
-# The PR branch is checked out locally — Read/Grep surrounding code at the PR's
-# version: look at how the changed code is called, check error handling paths
+# The PR's code is checked out in the worktree path given in your prompt — Read/Grep
+# there: look at how the changed code is called, check error handling paths
 ```
 
 For each concern, think: "How could this fail in production?"

--- a/agents/skeptical-reviewer.md
+++ b/agents/skeptical-reviewer.md
@@ -75,9 +75,14 @@ Ask: "If I trace through this code with specific inputs, do I get the correct ou
 - Information disclosure
 - Timing attacks
 
-### Freenet-Specific Bug Patterns (from Feb 2025 fix review — 25 bugs analyzed)
+### Freenet-Specific Bug Patterns
 
-These 5 patterns accounted for ALL 25 bugs in releases 0.1.147–0.1.150. Actively check for them:
+When reviewing **freenet-core**, the canonical and continuously-updated bug-pattern
+list is `.claude/rules/bug-prevention-patterns.md` in that repo — read it and check the
+PR against every pattern there. The five patterns below are a useful starting set
+(they accounted for a cluster of 25 production bugs in releases 0.1.147–0.1.150), but
+they are **not exhaustive** — the in-repo file has since grown well beyond them and is
+authoritative. Actively check for these, plus whatever else the canonical file lists:
 
 **1. `select!` Fairness Violations**
 - Any `biased;` select without per-iteration caps on high-throughput arms
@@ -118,9 +123,8 @@ These 5 patterns accounted for ALL 25 bugs in releases 0.1.147–0.1.150. Active
 # Get the diff
 gh pr diff <NUMBER>
 
-# Read related code for context
-# Look at how the changed code is called
-# Check error handling paths
+# The PR branch is checked out locally — Read/Grep surrounding code at the PR's
+# version: look at how the changed code is called, check error handling paths
 ```
 
 For each concern, think: "How could this fail in production?"

--- a/agents/testing-reviewer.md
+++ b/agents/testing-reviewer.md
@@ -40,6 +40,8 @@ Review the test coverage for PR changes and identify gaps that could allow bugs 
 ```bash
 gh pr diff <NUMBER>
 ```
+The PR branch is checked out locally — `Read`/`Grep` test files and the code under
+test at the PR's version, not just the diff.
 
 ### 2. Check Direct Coverage
 
@@ -88,7 +90,11 @@ For each gap found, be specific:
 
 ## Freenet-Specific Test Gaps to Check
 
-These 5 bug patterns caused ALL 25 bugs in releases 0.1.147–0.1.150. Check if the PR introduces or modifies code matching these patterns and whether tests cover them:
+When reviewing **freenet-core**, the canonical bug-pattern list is
+`.claude/rules/bug-prevention-patterns.md` in that repo — check whether the PR's tests
+cover every applicable pattern there. The five below are a starting set (from a cluster
+of 25 production bugs in releases 0.1.147–0.1.150); they are **not exhaustive** — treat
+the in-repo file as authoritative:
 
 | Pattern | What Tests Should Verify |
 |---------|------------------------|

--- a/agents/testing-reviewer.md
+++ b/agents/testing-reviewer.md
@@ -40,8 +40,8 @@ Review the test coverage for PR changes and identify gaps that could allow bugs 
 ```bash
 gh pr diff <NUMBER>
 ```
-The PR branch is checked out locally — `Read`/`Grep` test files and the code under
-test at the PR's version, not just the diff.
+The orchestrator's prompt gives you the absolute path to a worktree containing the
+PR's code — `Read`/`Grep` test files and the code under test there, not just the diff.
 
 ### 2. Check Direct Coverage
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,143 +1,136 @@
 ---
 name: pr-review
-description: Executes comprehensive PR reviews following Freenet standards. Performs four-perspective review covering code-first analysis, testing, skeptical review, and big-picture assessment.
+description: Executes a comprehensive multi-perspective PR review — runs four specialist subagents in parallel (code-first, testing, skeptical, big-picture) plus an external Codex pass, then posts a consolidated review to the PR.
 license: LGPL-3.0
 ---
 
 # PR Reviewer
 
-Execute a comprehensive PR review covering all four review perspectives from Freenet quality standards.
+Run a comprehensive PR review covering all four Freenet review perspectives, plus an
+external (non-Claude) model, and post a consolidated review to the PR.
 
 ## When to Use
 
-Use `/freenet:pr-review <PR-NUMBER>` after a PR is ready for review, before merging.
+Invoke `/freenet:pr-review <PR-NUMBER>` after a PR is ready for review, before merging.
+The PR number is passed as the skill argument (`$1`); if none is given, detect the PR
+for the current branch with `gh pr view --json number -q .number`.
 
-## Review Process
+## How This Skill Works
 
-### Step 1: Gather PR Context
+This skill **orchestrates** a review — it does not do all four perspectives by hand.
+It checks out the PR, spawns four specialist subagents in parallel plus an external
+Codex pass, reconciles their findings into one report, and posts that report to the PR.
+
+The four subagents ship with this plugin as first-class agent types — invoke them
+directly with the `Agent` tool's `subagent_type` parameter. Do **not** paste agent
+definitions into a `general-purpose` prompt; that is obsolete.
+
+## Step 1: Check Out the PR and Gather Context
+
+**Critical:** check out the PR branch before spawning reviewers. Otherwise their
+`Read`/`Grep` calls see `main`'s code, not the PR's, and the review is invalid.
 
 ```bash
-# Get PR details
-gh pr view <NUMBER>
+PR=<PR-NUMBER>          # the $1 skill argument
 
-# Get the diff
-gh pr diff <NUMBER>
+gh pr checkout "$PR"                  # reviewers now Read/Grep the PR's actual code
+gh pr view "$PR"
+gh pr diff "$PR" --name-only
+gh pr checks "$PR"                    # CI status
 
-# Check for linked issues
-# Look for "Fixes #XXX" or "Closes #XXX" in description
-gh issue view <ISSUE_NUMBER>  # if linked
+# Linked issues — read the full issue so the review can judge goal alignment
+#   look for "Fixes #XXX" / "Closes #XXX" in the description, then:
+gh issue view <ISSUE_NUMBER>
 
-# List affected files
-gh pr diff <NUMBER> --name-only
-
-# Check CI status
-gh pr checks <NUMBER>
+# Existing review feedback — read it so the review ADDRESSES it and does not
+# re-litigate or duplicate points already raised
+gh pr view "$PR" --json comments,reviews
+gh api repos/{owner}/{repo}/pulls/"$PR"/comments   # inline review comments
 ```
 
-### Step 2: Code-First Review
+Inline review comments are easy to miss — the `gh-pr-interactions` skill documents
+how to fetch every comment type reliably. Consult it if the PR already has review
+activity.
 
-Review the code **before** reading the PR description to form an independent understanding.
+**Large diffs:** if the diff exceeds ~2000 changed lines or ~40 files, instruct each
+subagent to review by file batches rather than loading the whole diff into context.
 
-**Process:**
-1. Read the diff without looking at the description
-2. Answer: What does this code do? What problem does it solve?
-3. Now read the PR description
-4. Compare your understanding with stated intent
-5. Flag any gaps or mismatches
+**Cleanup:** when the review is complete, restore the prior branch with `git checkout -`.
 
-**Look for:**
-- Does the code do what I think it should?
-- Are there hidden side effects?
-- Is the implementation approach sound?
+Optionally, before reviewing, run the `freenet:code-simplifier` agent so reviewers
+see the cleanest version of the code with up-to-date docs.
 
-### Step 3: Testing Review
+## Step 2: Spawn the Four Review Subagents in Parallel
 
-Analyze test coverage at all levels.
+Spawn all four with the `Agent` tool in a **single message** so they run
+concurrently, each with `run_in_background: true`:
 
-**Check for:**
-- Unit tests for new/modified functions
-- Integration tests for component interactions
-- Simulation tests for distributed behavior (if applicable)
-- E2E tests for user-facing changes
+| `subagent_type` | Perspective |
+|-----------------|-------------|
+| `freenet:code-first-reviewer` | Reads the code before the description; flags gaps between stated intent and implementation |
+| `freenet:testing-reviewer` | Test-coverage gaps at unit / integration / simulation / E2E levels |
+| `freenet:skeptical-reviewer` | Adversarial — bugs, race conditions, edge cases, failure modes |
+| `freenet:big-picture-reviewer` | Goal alignment, removed tests/fixes, scope creep, stale skills/docs |
 
-**Questions to answer:**
-- Does the regression test fail without the fix and pass with it?
-- Are edge cases covered?
-- Are error paths tested?
-- Would these tests catch similar bugs?
+In each subagent's prompt, include: the PR number, the repo (`owner/repo`), and a
+note that **the PR branch is already checked out locally**, so the agent should
+`Read`/`Grep` the PR's actual code — not just the diff — for surrounding context.
+Each agent already carries its own review methodology; you do not need to supply it.
 
-**Red flags:**
-- No tests for bug fixes
-- Tests that only check happy path
-- Removed or weakened test assertions
-- `#[ignore]` annotations
+## Step 3: External Codex Review (different model = different blind spots)
 
-### Step 4: Skeptical Review
+In parallel with Step 2, run an external review with a non-Claude model — it catches
+classes of issues Claude consistently misses. Invoke the `codex-review` skill, or run
+directly against the checked-out branch:
 
-Adversarial review looking for bugs, race conditions, and edge cases.
-
-**Attack vectors to explore:**
-- Race conditions in concurrent code
-- Integer overflow/underflow
-- Null/None handling
-- Resource leaks (memory, file handles, connections)
-- Error propagation gaps
-- State machine invalid transitions
-- Timeout and retry edge cases
-
-**For each change, ask:**
-- What happens if this fails?
-- What happens under high load?
-- What happens with malicious input?
-- What happens if called twice?
-- What happens if called out of order?
-
-**5 Recurring Bug Patterns (from Feb 2025 fix review — 25/25 bugs):**
-
-Check if the PR introduces or touches code matching these patterns:
-
-| Pattern | What to Look For |
-|---------|-----------------|
-| `biased;` select starvation | Per-iteration caps? Cancellation safety? Which arm starves? |
-| Fire-and-forget spawns | JoinHandle stored? `try_send` on critical paths? Catch-all `_ =>` in metrics? |
-| State cleanup on failure | ALL related maps cleaned up? Peer lists filtered to live connections? GC exemptions time-bounded? |
-| Backoff without jitter | Jitter ±20%? Sleep interruptible via `select!`? Zero-connection re-bootstrap? Critical msgs retried? |
-| Deployment gaps | Exit codes declared? Auto-update gated on release? Security tested against app needs? Unused deps? |
-
-### Step 5: Big Picture Review
-
-Ensure the PR actually solves the stated problem and doesn't exhibit "CI chasing" anti-patterns.
-
-**Check for removed code:**
 ```bash
-# Look for deleted tests or fix code
-gh pr diff <NUMBER> | grep -E '^-.*#\[test\]|^-.*fn test_|^-.*assert'
+codex review --base main
 ```
 
-**Anti-patterns to detect:**
-| Anti-Pattern | What to Look For |
-|--------------|------------------|
-| Ignored tests | `#[ignore]`, `skip`, `@Ignore` |
-| Weakened assertions | Looser tolerances, `.ok()` on Results |
-| Commented code | Especially tests or validation |
-| Magic numbers | Hardcoded values replacing logic |
-| Error swallowing | `.unwrap_or_default()`, silent fallbacks |
+For a third independent model, the `gemini-cli-review` skill is also available — worth
+using on high-risk PRs (security, consensus, wire format, migrations).
 
-**Big picture questions:**
-1. Does this PR actually solve the stated problem?
-2. Does it fully address the linked issue?
-3. Does it conflict with other open PRs?
-4. Does it introduce patterns that will cause future problems?
-5. Is there scope creep?
+## Step 4: Freenet Bug-Pattern Check
 
-### Step 6: Documentation Review
+When reviewing **freenet-core**, the canonical and continuously-updated bug-pattern
+list lives at `.claude/rules/bug-prevention-patterns.md` in that repo. Read it and
+check the PR against every pattern listed there — it supersedes any snapshot in this
+skill or in the subagent definitions.
 
-Check if documentation is complete:
+Recurring patterns (non-exhaustive — the in-repo file is authoritative): `biased;`
+select starvation, fire-and-forget spawns, incomplete state cleanup on failure,
+backoff without jitter, `.send().await` on bounded channels inside event/recv loops,
+protocol-enum / wire-format breaks for older consumers, paired `Option` fields that
+must co-occur, and manually-mirrored telemetry counters that rot after op migrations.
 
-- **Code docs:** Do new public items have doc comments?
-- **Architecture docs:** Do changes require doc updates?
-- **User docs:** Are CLI/config changes documented?
-- **Stale docs:** Do any existing docs contradict the changes?
+## Step 5: Synthesize — Reconcile and Verify
+
+When all four subagents and the Codex pass have returned, **do not just concatenate
+their reports.** Synthesize:
+
+1. **Deduplicate** — the same finding will surface from multiple reviewers; merge it
+   into one entry.
+2. **Reconcile contradictions** — if two reviewers disagree, investigate the code
+   yourself and decide; note the disagreement in the report if it is genuinely open.
+3. **Verify before reporting** — subagents and Codex can cite wrong line numbers or
+   hallucinate. Open every cited `file:line` and confirm the finding is real before it
+   goes in the report. Drop false positives; downgrade speculative ones to questions.
+4. **Classify severity** — map every surviving finding to Must Fix / Should Fix /
+   Consider (see Output Format).
+5. **Check documentation** — new public items have doc comments? CLI/config changes
+   documented? Any existing doc now contradicted by the change?
+
+## Step 6: Post the Consolidated Review to the PR
+
+Post the synthesized report to the PR as a review comment:
+
+```bash
+gh pr review "$PR" --comment --body-file <report-file>
+```
+
+Use `--comment` — not `--approve` or `--request-changes`. This skill produces a
+review; it does not gate merge or speak for a human approver. Also print the report
+in the conversation. End the posted body with `[AI-assisted - Claude]`.
 
 ## Output Format
 
@@ -151,6 +144,7 @@ Produce a consolidated review report:
 - **Type:** <feat/fix/refactor/etc>
 - **CI Status:** <passing/failing/pending>
 - **Linked Issues:** <issue numbers or "none">
+- **Reviewers run:** code-first, testing, skeptical, big-picture, Codex<, Gemini>
 
 ---
 
@@ -182,7 +176,7 @@ Produce a consolidated review report:
 
 | Concern | Severity | Location | Details |
 |---------|----------|----------|---------|
-| <issue> | <high/med/low> | <file:line> | <explanation> |
+| <issue> | <high/med/low> | <file:line — verified> | <explanation> |
 
 ---
 
@@ -219,31 +213,9 @@ Produce a consolidated review report:
 **HEAD SHA reviewed:** <sha>
 
 <If not ready, summarize what's needed. If re-review is required, list which findings triggered it so the next pass can confirm they're addressed.>
+
+[AI-assisted - Claude]
 ```
-
-## Parallel Subagent Reviews
-
-For deeper analysis, spawn the specialized review agents in parallel using the Task tool with `subagent_type="general-purpose"`. Include the agent definition (from `agents/`) in each prompt so the subagent follows the correct review methodology.
-
-```
-Spawn all four in parallel using Task tool (all use subagent_type="general-purpose"):
-
-1. "You are a code-first-reviewer. [Include agents/code-first-reviewer.md instructions]
-    Review PR #<NUMBER> in freenet/freenet-core"
-
-2. "You are a testing-reviewer. [Include agents/testing-reviewer.md instructions]
-    Review test coverage for PR #<NUMBER> in freenet/freenet-core"
-
-3. "You are a skeptical-reviewer. [Include agents/skeptical-reviewer.md instructions]
-    Do a skeptical review of PR #<NUMBER> in freenet/freenet-core"
-
-4. "You are a big-picture-reviewer. [Include agents/big-picture-reviewer.md instructions]
-    Do a big-picture review of PR #<NUMBER> in freenet/freenet-core"
-```
-
-## External Skeptical Review with Codex
-
-After completing the internal review, ask Codex to do a skeptical review of the PR. Codex uses a different model and catches different classes of issues — having an independent perspective reduces blind spots. Share the PR number and ask it to look for bugs, race conditions, edge cases, and failure modes. Incorporate any findings into the final review report.
 
 ## Re-Review After Fixes (Mandatory When Findings Were Significant)
 
@@ -251,7 +223,7 @@ A review is per-CODE-CONTENT, not per-PR. If the review surfaced significant pro
 
 ### When re-review is required
 
-Re-run the full review (Steps 1–6, parallel subagents, and Codex) if **any** of the following is true after fixes are pushed:
+Re-run the full review (all of Steps 1–6) if **any** of the following is true after fixes are pushed:
 
 - **One or more "Must Fix" (blocking) findings** were addressed — even a single blocking fix can introduce its own bugs.
 - **Three or more "Should Fix" findings** were addressed in aggregate — many small changes compound into substantial new surface area.
@@ -278,15 +250,15 @@ In that case, do a focused diff-of-the-diff check (just the new commits since th
    ```bash
    gh pr view <NUMBER> --json statusCheckRollup,headRefOid
    ```
-2. Re-run Steps 1–6 against the new HEAD. Read the *full* diff again, not just the fix commits — context shifts when code moves.
-3. Re-spawn the four parallel subagent reviews against the new HEAD.
-4. Re-run Codex review against the new HEAD.
-5. Produce a fresh review report. In the **Verdict** section, explicitly note this is a re-review and reference the prior review's findings: "Re-review after fixes for findings #1, #3, #5 from prior pass — all resolved; one new concern at X."
-6. If the new review surfaces its own significant findings, repeat the cycle. There is no cap on rounds; merge only when a review pass on the current HEAD comes back clean (or with only trivial findings the user accepts).
+2. Re-run all of Steps 1–6 against the new HEAD — re-checkout the branch, re-spawn the
+   four parallel subagents, and re-run Codex. Read the *full* diff again, not just the
+   fix commits — context shifts when code moves.
+3. Produce a fresh review report. In the **Verdict** section, explicitly note this is a re-review and reference the prior review's findings: "Re-review after fixes for findings #1, #3, #5 from prior pass — all resolved; one new concern at X."
+4. If the new review surfaces its own significant findings, repeat the cycle. There is no cap on rounds; merge only when a review pass on the current HEAD comes back clean (or with only trivial findings the user accepts).
 
-### Verdict states involving re-review
+### What the re-review verdict states mean
 
-Extend the Output Format's Verdict to one of:
+The Verdict states (defined in Output Format) are:
 
 - **Ready to Merge** — review pass on current HEAD is clean or only trivial findings remain.
 - **Needs Changes — Re-review Required After Fix** — significant findings exist; author must address them AND a fresh review must run on the updated HEAD before merge.
@@ -298,7 +270,7 @@ Never use "Ready to Merge" on the basis of a review whose HEAD SHA differs from 
 ## Quality Standards
 
 - Be thorough but constructive
-- Cite specific files and line numbers
+- Cite specific files and line numbers — and verify each citation before reporting it
 - Explain WHY something is a problem, not just WHAT
 - Suggest fixes, not just criticisms
 - Acknowledge what's done well

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -35,11 +35,14 @@ uncommitted changes onto the PR branch, contaminating the review.
 
 ```bash
 PR=<PR-NUMBER>          # the $1 skill argument
+BASE="$(gh pr view "$PR" --json baseRefName -q .baseRefName)"   # the PR's base branch
 
-git fetch origin "pull/$PR/head"
-REVIEW_DIR="$(mktemp -d)/pr-$PR"
-git worktree add --detach "$REVIEW_DIR" FETCH_HEAD   # PR code, isolated
-cd "$REVIEW_DIR"                                     # run the review from here
+git fetch origin "$BASE"                 # fresh base branch for the diff
+git fetch origin "pull/$PR/head"         # PR head — FETCH_HEAD now points here
+REVIEW_DIR="${TMPDIR:-/tmp}/pr-review-$PR"
+git worktree remove --force "$REVIEW_DIR" 2>/dev/null || true   # prune a stale prior worktree
+git worktree add --detach "$REVIEW_DIR" FETCH_HEAD              # PR code, isolated
+cd "$REVIEW_DIR"                                                # run the review from here
 ```
 
 Gather context (from the worktree):
@@ -123,11 +126,12 @@ carries its own review methodology; you do not need to supply it.
 
 Run this for **both Light and Full** tiers — the external model is the highest-value
 single pass, because its blind spots do not correlate with Claude-authored code.
-Spawn it concurrently with Step 2's subagents. Run a non-Claude model against the
-review worktree:
+Spawn it concurrently with Step 2's subagents. Run a non-Claude model from the review
+worktree, diffing against the PR's base branch (`$BASE`, fetched fresh in Step 1) —
+never a possibly-stale local `main`:
 
 ```bash
-codex review --base main
+codex review --base "origin/$BASE"
 ```
 
 (If your environment provides a `codex-review` skill, it wraps this command.) For a

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Executes a comprehensive multi-perspective PR review — runs four specialist subagents in parallel (code-first, testing, skeptical, big-picture) plus an external Codex pass, then posts a consolidated review to the PR.
+description: Executes a risk-tiered, multi-perspective PR review — triages the change, runs specialist subagents in parallel (code-first, testing, skeptical, big-picture) plus an external model pass scaled to risk, then posts a consolidated review to the PR.
 license: LGPL-3.0
 ---
 
@@ -17,15 +17,16 @@ for the current branch with `gh pr view --json number -q .number`.
 
 ## How This Skill Works
 
-This skill **orchestrates** a review — it does not do all four perspectives by hand.
-It checks out the PR, spawns four specialist subagents in parallel plus an external
-Codex pass, reconciles their findings into one report, and posts that report to the PR.
+This skill **orchestrates** a review — it does not do all the perspectives by hand.
+It checks out the PR, triages the change to a risk tier, spawns specialist subagents
+in parallel (scaled to that tier) plus an external model pass, reconciles their
+findings into one report, and posts that report to the PR.
 
 The four subagents ship with this plugin as first-class agent types — invoke them
 directly with the `Agent` tool's `subagent_type` parameter. Do **not** paste agent
 definitions into a `general-purpose` prompt; that is obsolete.
 
-## Step 1: Check Out the PR and Gather Context
+## Step 1: Check Out the PR, Gather Context, and Triage Risk
 
 **Critical:** check out the PR branch before spawning reviewers. Otherwise their
 `Read`/`Grep` calls see `main`'s code, not the PR's, and the review is invalid.
@@ -60,10 +61,37 @@ subagent to review by file batches rather than loading the whole diff into conte
 Optionally, before reviewing, run the `freenet:code-simplifier` agent so reviewers
 see the cleanest version of the code with up-to-date docs.
 
-## Step 2: Spawn the Four Review Subagents in Parallel
+### Pick the Risk Tier
 
-Spawn all four with the `Agent` tool in a **single message** so they run
-concurrently, each with `run_in_background: true`:
+Using the diff size and the files touched, choose the review tier — or honor an
+explicit tier the user named (e.g. "full review of PR 42"). Tiers are defined in the
+multi-model-review standard:
+
+- **Skip** — typo / comment-only / formatting / version bump / CHANGELOG-only, or
+  similarly mechanical. Report "trivial — CI is the only gate" and **stop**; do not
+  spawn reviewers.
+- **Light** — low-risk, small, self-contained diff with no high-risk surface. Spawn a
+  reduced reviewer set (Step 2) plus the external model pass (Step 3).
+- **Full** — touches a high-risk surface, or a large / cross-cutting diff, or genuine
+  uncertainty. Run the complete process.
+
+**High-risk surfaces — always Full:** concurrency / async, cryptography / security /
+auth, state authorization, data or schema migration, wire format / protocol /
+serialization (freenet-stdlib enums), consensus / routing, transport / NAT traversal,
+contract or delegate WASM, deploy / release / CI config. When torn, pick the heavier
+tier.
+
+State the chosen tier and the one-line reason before proceeding.
+
+## Step 2: Spawn the Review Subagents in Parallel
+
+Spawn the reviewers with the `Agent` tool in a **single message** so they run
+concurrently, each with `run_in_background: true`. Which reviewers run depends on the
+tier picked in Step 1:
+
+- **Full** — spawn all four.
+- **Light** — spawn `freenet:skeptical-reviewer`; also spawn `freenet:big-picture-reviewer`
+  if the diff removes code or spans multiple components.
 
 | `subagent_type` | Perspective |
 |-----------------|-------------|
@@ -79,9 +107,10 @@ Each agent already carries its own review methodology; you do not need to supply
 
 ## Step 3: External Codex Review (different model = different blind spots)
 
-In parallel with Step 2, run an external review with a non-Claude model — it catches
-classes of issues Claude consistently misses. Invoke the `codex-review` skill, or run
-directly against the checked-out branch:
+Run this for **both Light and Full** tiers — the external model is the highest-value
+single pass, because its blind spots do not correlate with Claude-authored code.
+In parallel with Step 2, run the external review with a non-Claude model. Invoke the
+`codex-review` skill, or run directly against the checked-out branch:
 
 ```bash
 codex review --base main
@@ -91,6 +120,9 @@ For a third independent model, the `gemini-cli-review` skill is also available �
 using on high-risk PRs (security, consensus, wire format, migrations).
 
 ## Step 4: Freenet Bug-Pattern Check
+
+Do this for **Full** reviews, and for **Light** reviews whose change has non-trivial
+logic.
 
 When reviewing **freenet-core**, the canonical and continuously-updated bug-pattern
 list lives at `.claude/rules/bug-prevention-patterns.md` in that repo. Read it and
@@ -144,7 +176,8 @@ Produce a consolidated review report:
 - **Type:** <feat/fix/refactor/etc>
 - **CI Status:** <passing/failing/pending>
 - **Linked Issues:** <issue numbers or "none">
-- **Reviewers run:** code-first, testing, skeptical, big-picture, Codex<, Gemini>
+- **Review tier:** <Light / Full>
+- **Reviewers run:** <which reviewers and external models actually ran>
 
 ---
 
@@ -250,9 +283,9 @@ In that case, do a focused diff-of-the-diff check (just the new commits since th
    ```bash
    gh pr view <NUMBER> --json statusCheckRollup,headRefOid
    ```
-2. Re-run all of Steps 1–6 against the new HEAD — re-checkout the branch, re-spawn the
-   four parallel subagents, and re-run Codex. Read the *full* diff again, not just the
-   fix commits — context shifts when code moves.
+2. Re-run all of Steps 1–6 against the new HEAD — re-checkout the branch, re-triage,
+   re-spawn the tier's reviewers, and re-run the external model pass. Read the *full*
+   diff again, not just the fix commits — context shifts when code moves.
 3. Produce a fresh review report. In the **Verdict** section, explicitly note this is a re-review and reference the prior review's findings: "Re-review after fixes for findings #1, #3, #5 from prior pass — all resolved; one new concern at X."
 4. If the new review surfaces its own significant findings, repeat the cycle. There is no cap on rounds; merge only when a review pass on the current HEAD comes back clean (or with only trivial findings the user accepts).
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -28,58 +28,68 @@ definitions into a `general-purpose` prompt; that is obsolete.
 
 ## Step 1: Check Out the PR, Gather Context, and Triage Risk
 
-**Critical:** check out the PR branch before spawning reviewers. Otherwise their
-`Read`/`Grep` calls see `main`'s code, not the PR's, and the review is invalid.
+**Critical:** reviewers must read the PR's *actual code*, and the review must not
+disturb the user's working tree. Check the PR out into a **dedicated worktree** — do
+NOT use `gh pr checkout`, which switches the user's working branch and drags any
+uncommitted changes onto the PR branch, contaminating the review.
 
 ```bash
 PR=<PR-NUMBER>          # the $1 skill argument
 
-gh pr checkout "$PR"                  # reviewers now Read/Grep the PR's actual code
+git fetch origin "pull/$PR/head"
+REVIEW_DIR="$(mktemp -d)/pr-$PR"
+git worktree add --detach "$REVIEW_DIR" FETCH_HEAD   # PR code, isolated
+cd "$REVIEW_DIR"                                     # run the review from here
+```
+
+Gather context (from the worktree):
+
+```bash
 gh pr view "$PR"
 gh pr diff "$PR" --name-only
 gh pr checks "$PR"                    # CI status
+gh issue view <ISSUE_NUMBER>          # linked issue (from "Fixes #" / "Closes #")
 
-# Linked issues — read the full issue so the review can judge goal alignment
-#   look for "Fixes #XXX" / "Closes #XXX" in the description, then:
-gh issue view <ISSUE_NUMBER>
-
-# Existing review feedback — read it so the review ADDRESSES it and does not
-# re-litigate or duplicate points already raised
+# Existing review feedback — read it so the review ADDRESSES it, not duplicates it:
 gh pr view "$PR" --json comments,reviews
 gh api repos/{owner}/{repo}/pulls/"$PR"/comments   # inline review comments
 ```
 
-Inline review comments are easy to miss — the `gh-pr-interactions` skill documents
-how to fetch every comment type reliably. Consult it if the PR already has review
-activity.
+The `gh api .../comments` call above is the reliable way to get inline comments —
+they are easy to miss. (If your environment provides a `gh-pr-interactions` skill, it
+documents the comment API in more depth.)
 
 **Large diffs:** if the diff exceeds ~2000 changed lines or ~40 files, instruct each
 subagent to review by file batches rather than loading the whole diff into context.
 
-**Cleanup:** when the review is complete, restore the prior branch with `git checkout -`.
+**Cleanup (mandatory — do this even if the review aborts partway):** remove the
+worktree with `git worktree remove --force "$REVIEW_DIR"`.
 
-Optionally, before reviewing, run the `freenet:code-simplifier` agent so reviewers
-see the cleanest version of the code with up-to-date docs.
+Do NOT run a code-simplifier or any other mutating step here — this skill reviews the
+PR as submitted; editing the checked-out code would make reviewers judge something
+other than the PR.
 
 ### Pick the Risk Tier
 
-Using the diff size and the files touched, choose the review tier — or honor an
-explicit tier the user named (e.g. "full review of PR 42"). Tiers are defined in the
-multi-model-review standard:
+Choose the tier by checking these in order — **first match wins** — or honor an
+explicit tier the user named (e.g. "full review of PR 42"):
 
-- **Skip** — typo / comment-only / formatting / version bump / CHANGELOG-only, or
-  similarly mechanical. Report "trivial — CI is the only gate" and **stop**; do not
-  spawn reviewers.
-- **Light** — low-risk, small, self-contained diff with no high-risk surface. Spawn a
-  reduced reviewer set (Step 2) plus the external model pass (Step 3).
-- **Full** — touches a high-risk surface, or a large / cross-cutting diff, or genuine
-  uncertainty. Run the complete process.
+1. **Skip** — the *entire* diff is mechanical: typo / comment-only / formatting /
+   version bump / CHANGELOG-only. Judge this against the whole diff, not the PR title —
+   a PR labelled "version bump" that also edits logic is **not** Skip. Report
+   "trivial — CI is the only gate" and **stop**; do not spawn reviewers.
+2. **Full** — the change touches a high-risk surface (below), OR the diff is large or
+   cross-cutting, OR you are genuinely uncertain. Run the complete process.
+3. **Light** — everything else: a low-to-moderate-risk change with no high-risk
+   surface. Spawn a reduced reviewer set (Step 2) plus the external model pass (Step 3).
+
+These tiers are exhaustive — Light is the catch-all. When torn between two, pick the
+heavier one.
 
 **High-risk surfaces — always Full:** concurrency / async, cryptography / security /
 auth, state authorization, data or schema migration, wire format / protocol /
 serialization (freenet-stdlib enums), consensus / routing, transport / NAT traversal,
-contract or delegate WASM, deploy / release / CI config. When torn, pick the heavier
-tier.
+contract or delegate WASM, deploy / release / CI config.
 
 State the chosen tier and the one-line reason before proceeding.
 
@@ -100,24 +110,29 @@ tier picked in Step 1:
 | `freenet:skeptical-reviewer` | Adversarial — bugs, race conditions, edge cases, failure modes |
 | `freenet:big-picture-reviewer` | Goal alignment, removed tests/fixes, scope creep, stale skills/docs |
 
-In each subagent's prompt, include: the PR number, the repo (`owner/repo`), and a
-note that **the PR branch is already checked out locally**, so the agent should
-`Read`/`Grep` the PR's actual code — not just the diff — for surrounding context.
-Each agent already carries its own review methodology; you do not need to supply it.
+These `subagent_type` values are plugin-namespaced: `freenet:` is the plugin name and
+the files in `agents/` carry the bare name (`skeptical-reviewer`, etc.). Use the
+`freenet:`-prefixed form exactly as shown.
 
-## Step 3: External Codex Review (different model = different blind spots)
+In each subagent's prompt, include: the PR number, the repo (`owner/repo`), and the
+path to the review worktree from Step 1 (`$REVIEW_DIR`), so the agent can `Read`/`Grep`
+the PR's actual code — not just the diff — for surrounding context. Each agent already
+carries its own review methodology; you do not need to supply it.
+
+## Step 3: External Model Review (runs concurrently with Step 2)
 
 Run this for **both Light and Full** tiers — the external model is the highest-value
 single pass, because its blind spots do not correlate with Claude-authored code.
-In parallel with Step 2, run the external review with a non-Claude model. Invoke the
-`codex-review` skill, or run directly against the checked-out branch:
+Spawn it concurrently with Step 2's subagents. Run a non-Claude model against the
+review worktree:
 
 ```bash
 codex review --base main
 ```
 
-For a third independent model, the `gemini-cli-review` skill is also available — worth
-using on high-risk PRs (security, consensus, wire format, migrations).
+(If your environment provides a `codex-review` skill, it wraps this command.) For a
+Full review of a high-risk PR, add a third independent model when one is available —
+e.g. a `gemini-cli-review` skill or the `gemini` CLI.
 
 ## Step 4: Freenet Bug-Pattern Check
 
@@ -137,8 +152,8 @@ must co-occur, and manually-mirrored telemetry counters that rot after op migrat
 
 ## Step 5: Synthesize — Reconcile and Verify
 
-When all four subagents and the Codex pass have returned, **do not just concatenate
-their reports.** Synthesize:
+When all spawned subagents and the external model pass have returned, **do not just
+concatenate their reports.** Synthesize:
 
 1. **Deduplicate** — the same finding will surface from multiple reviewers; merge it
    into one entry.
@@ -283,9 +298,12 @@ In that case, do a focused diff-of-the-diff check (just the new commits since th
    ```bash
    gh pr view <NUMBER> --json statusCheckRollup,headRefOid
    ```
-2. Re-run all of Steps 1–6 against the new HEAD — re-checkout the branch, re-triage,
-   re-spawn the tier's reviewers, and re-run the external model pass. Read the *full*
-   diff again, not just the fix commits — context shifts when code moves.
+2. Re-run all of Steps 1–6 against the new HEAD — re-create the review worktree,
+   re-triage, re-spawn the tier's reviewers, and re-run the external model pass. Read
+   the *full* diff again, not just the fix commits — context shifts when code moves.
+   Re-triage against the **whole PR diff vs. base**, not just the fix commits: the
+   tier may rise but never falls below the original review's tier (a PR that needed a
+   Full review does not become Skip because the last fix was one line).
 3. Produce a fresh review report. In the **Verdict** section, explicitly note this is a re-review and reference the prior review's findings: "Re-review after fixes for findings #1, #3, #5 from prior pass — all resolved; one new concern at X."
 4. If the new review surfaces its own significant findings, repeat the cycle. There is no cap on rounds; merge only when a review pass on the current HEAD comes back clean (or with only trivial findings the user accepts).
 


### PR DESCRIPTION
## Problem

The `pr-review` skill's mechanics had drifted from current Claude Code capabilities and PR-review best practices:

- The PR branch was never checked out — reviewers' `Read`/`Grep` saw `main`'s code, not the PR's
- Parallel subagents were framed as an optional addendum, not the default path
- Spawn instructions predated the now-installed `freenet:*` reviewer subagents (told you to paste agent defs into a `general-purpose` prompt)
- No synthesis step (dedup / reconcile / verify cited `file:line`)
- The review never landed on the PR — chat-only report
- The bug-pattern list was frozen at a Feb-2025 snapshot
- Every PR got identical review effort regardless of risk

## Approach

- Parallel subagents are now the default path, invoked as first-class `subagent_type`s with `run_in_background`
- Step 1 checks out the PR branch so reviewers see the PR's actual code; added checkout-awareness notes to all four agent defs
- Added a synthesis step (dedup / reconcile / verify citations) and a `gh pr review --comment` posting step
- Fetches existing PR comments up front to avoid duplicating prior feedback
- De-staled bug-pattern guidance — SKILL.md and the skeptical/testing agents point at the canonical `bug-prevention-patterns.md` in freenet-core
- Added a three-tier risk model (Skip / Light / Full) so review effort scales to the change; high-risk surfaces always get Full

The companion global `multi-model-review` rule was thinned to delegate all mechanics to this skill (single source of truth).

## Testing

Docs / skill-instruction change — no automated tests. `version-check` CI validates the version bump + CHANGELOG entry. Reviewed at Light tier (Codex + skeptical reviewer) per the multi-model-review standard.

Version bumped 1.0.19 → 1.1.0.

[AI-assisted - Claude]