### PR TITLE
feat(dapp-builder): add TypeScript+Vite UI path and align with freenet-stdlib v0.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,39 @@ matrices, upstream-bug quarantine) deliberately left out of this version
   River smoke test → post-release health check. Net effect: skill shrunk
   from 312 to ~145 lines and now matches what the pipeline actually does.
 
+## 1.4.0 (2026-05-28)
+
+Stacked on top of 1.3.0 (mail-practices sync). Aligns `dapp-builder` +
+`local-dev` with freenet-stdlib v0.8.0 (Rust) and
+`@freenetorg/freenet-stdlib` v0.2.0 (TypeScript). Pre-existing 0.6.0
+pins were two releases behind; this catches up and documents the deltas
+in between. Bumped the inbox-contract lockfile-isolation example added
+in 1.3.0 from `=0.6.0` to `=0.8.0` to match.
+- `dapp-builder/SKILL.md`:
+  - Added **TypeScript + Vite** as a first-class UI option (Phase 3 / Option B) alongside Dioxus, including a parallel project structure template and an npm/Vite dependency table.
+  - Bumped Rust `freenet-stdlib` pins from `"0.6.0"` to `"0.8"` (workspace + UI crate); added TypeScript pin `"@freenetorg/freenet-stdlib": "^0.2.0"`.
+  - Added security note about stdlib v0.6.0 removal of public `DEFAULT_CIPHER`/`DEFAULT_NONCE` constants (PR #75) — delegates must now generate random cipher/nonce per session.
+- `dapp-builder/references/ui-patterns.md`:
+  - New TypeScript + Vite section covering the FlatBuffers serialization model, contract/delegate hash injection at build time, and the dynamic-import pattern for internal `-T` types.
+  - Bumped Cargo.toml stdlib pin to `"0.8"`.
+  - Completed the `ResponseHandler` example with v0.2.0 callbacks `onContractNotFound`, `onSubscribeResponse`, `onClose`.
+  - Converted `api.get/put/update/subscribe` examples to the **promise-based API** (`await api.X(...)` + try/catch). Noted that callbacks still fire alongside promises for backward compatibility and that the default request timeout is 30 s.
+  - New section "Large state handling (streaming)" covers `CHUNK_THRESHOLD = 512 KB`, `CHUNK_SIZE = 256 KB`, `ReassemblyBuffer`, and the v0.2.0 concurrency limits.
+  - Added warning above the `(api as any).sendRequest(...)` cast — internal SDK method, may break on any minor SDK bump; track stdlib for a public delegate-message builder.
+- `dapp-builder/references/delegate-patterns.md`:
+  - Renamed `attested: Option<&'static [u8]>` parameter to `origin: Option<MessageOrigin>` in `DelegateInterface::process()` examples (stdlib v0.5 breaking change).
+  - New section "Inter-delegate messaging" covering `MessageOrigin::WebApp(ContractInstanceId)` vs `MessageOrigin::Delegate(DelegateKey)` (PR #65), with a whitelist-based authorization pattern and the note that an inter-delegate message replaces (not composes with) any inherited `WebApp` origin.
+  - Added wildcard `_ => {}` arms to all `InboundDelegateMsg` matches with comments noting the `#[non_exhaustive]` requirement from stdlib v0.6.0 (PR #66).
+  - Added API drift note flagging that the pre-v0.5 secrets-by-message pattern is now `DelegateCtx::get_secret/set_secret` synchronously.
+- `dapp-builder/references/build-system.md`:
+  - Added TypeScript + Vite plain-`Makefile` block alongside the Rust + cargo-make flow; documented that River uses cargo-make and freenet-microblogging uses plain Make + Vite.
+  - **`fdev publish` differs for contracts vs delegates.** Contracts take raw `target/wasm32-unknown-unknown/release/*.wasm`; delegates take the packaged file from `build/freenet/` produced by `fdev build --package-type delegate`. Wrong file type → silent failure or cryptic errors.
+  - Documented the ANSI-strip pattern when piping `fdev` output (`sed 's/\x1b\[[0-9;]*m//g'`) and the `clean-node` pattern for republishing under the same key during dev.
+  - Bumped Rust workspace stdlib pin from `"0.6.0"` to `"0.8"`; bumped the inbox-contract lockfile-isolation example added in 1.3.0 to `=0.8.0` to match.
+- `local-dev/SKILL.md`:
+  - Renamed "seeding contracts" → "hosting contracts" in `NodeDiagnosticsConfig` comment to match the stdlib terminology rename (PR #64).
+  - Added wire-format note: `NodeDiagnosticsResponse.contract_states` is now `HashMap<String, ContractState>` with Base58-encoded keys (PR #70, v0.7.0 bidirectional bincode break).
+
 ## 1.2.0 (2026-05-21)
 - Added `dapp-builder` reference `identity-and-addressing.md`: how to give users a
   short, stable, shareable identifier without leaking raw key material or coupling
@@ -233,7 +266,6 @@ matrices, upstream-bug quarantine) deliberately left out of this version
   (CLI / dev-server / direct node access, manual `Authenticate` required)
 - Includes prior unreleased commit 265a7de: release skill Step 6 now enumerates
   the 12 required platform binaries explicitly (freenet/freenet-core#3825)
-
 ## 1.0.14 (2026-04-10)
 - Fixed dapp-builder: WebSocket connection documentation was incorrect
   - WebSocket URL must be derived from `window.location`, not hardcoded to `ws://127.0.0.1:7509`

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -129,12 +129,11 @@ Reference: `references/delegate-patterns.md`
 
 ### Phase 3: UI Design
 
-Build the user interface connecting to contracts and delegates.
+Build the user interface connecting to contracts and delegates. Two approaches:
 
-**Key questions:**
-- What components/views does the app need?
-- How should state synchronization work?
-- What's the user flow for key operations?
+#### Option A: Dioxus (Rust → WASM)
+
+Best for: teams already in Rust, complex state logic shared with contracts.
 
 **Implementation steps:**
 1. Set up Dioxus project with WASM target
@@ -149,6 +148,18 @@ Build the user interface connecting to contracts and delegates.
    `vite dev`. See `references/ui-patterns.md` "Gateway CSP: Vendor Your
    Assets".
 
+#### Option B: TypeScript + Vite
+
+Best for: web developers, faster iteration, familiar tooling (npm, SCSS, etc.).
+
+**Implementation steps:**
+1. Set up Vite project with `@freenetorg/freenet-stdlib` (TypeScript package)
+2. Use `FreenetWsApi` class for WebSocket connection (handles FlatBuffers serialization)
+3. Pass empty string auth token to `FreenetWsApi` constructor (sandbox blocks cookie reading)
+4. Use Vite `define` to inject contract hashes and delegate key bytes at build time
+5. For delegate communication, dynamically import internal FlatBuffers types (`ClientRequestT`, `ApplicationMessagesT`, etc.)
+6. Build reactive UI with vanilla TS, or any framework (React, Vue, Svelte)
+
 Reference: `references/ui-patterns.md`
 
 ### Phase 4: Build, Test, and Deploy
@@ -156,8 +167,8 @@ Reference: `references/ui-patterns.md`
 Set up the build system, CI, and deployment pipeline.
 
 **Implementation steps:**
-1. Set up `Makefile.toml` with build tasks for contract, delegate, and UI
-2. Add a `preflight` task that runs fmt, clippy, tests, and migration checks before publish
+1. Set up build orchestration — either `Makefile.toml` (cargo-make) or plain `Makefile`
+2. Add a preflight task that runs fmt, clippy, tests, and migration checks before publish
 3. Add GitHub Actions CI workflow (runs on push and PRs)
 4. Back up contract state to the delegate for network resilience
 5. **Add a production-liveness smoke test.** A ~50-line Playwright spec
@@ -192,7 +203,9 @@ References:
 - `references/facade-pattern.md` — stable-URL facade contract
   architecture for projects that ship more than one release.
 
-## Project Structure Template
+## Project Structure Templates
+
+### Dioxus (Rust) UI
 
 ```
 my-dapp/
@@ -222,6 +235,34 @@ my-dapp/
 └── Makefile.toml             # cargo-make build tasks
 ```
 
+### TypeScript + Vite UI
+
+```
+my-dapp/
+├── contracts/
+│   └── my-contract/
+│       ├── Cargo.toml
+│       └── src/lib.rs        # ContractInterface implementation
+├── delegates/
+│   └── my-delegate/
+│       ├── Cargo.toml
+│       └── src/lib.rs        # DelegateInterface implementation
+├── web/
+│   ├── package.json
+│   ├── vite.config.ts         # Injects contract/delegate keys at build time
+│   ├── tsconfig.json
+│   ├── index.html
+│   └── src/
+│       ├── index.ts           # Entry point, connection flow
+│       ├── freenet-api.ts     # FreenetWsApi wrapper
+│       ├── delegate-api.ts    # Delegate FlatBuffers message building
+│       ├── identity.ts        # Identity management (delegate + fallback)
+│       ├── types.ts           # Shared TypeScript types
+│       └── components/        # UI components
+├── Cargo.toml                 # Workspace root (contracts + delegates)
+└── Makefile                   # Build orchestration
+```
+
 ## Reference Project
 
 [River](https://github.com/freenet/river) demonstrates all patterns:
@@ -237,11 +278,18 @@ deserialization failures, missing features, and "variant index out of range"
 errors. Check [River's workspace Cargo.toml](https://github.com/freenet/river/blob/main/Cargo.toml)
 before pinning.
 
-As of April 2026 (River `main`):
+As of May 2026 — River pins `freenet-stdlib = "0.6.0"` but the upstream
+crate is now `0.8` (0.6 → 0.7 added Base58-stringified `contract_states`
+keys in `NodeDiagnosticsResponse`; 0.7 → 0.8 hardened wire-boundary enums
+with `#[non_exhaustive]` and removed the world-known `DEFAULT_CIPHER` /
+`DEFAULT_NONCE` constants). If you build only against River, mirror its
+pin; if your code links into stdlib 0.8 directly, you need the bumped
+version *and* the wildcard match arms / random cipher generation
+documented in `references/delegate-patterns.md`.
 
 ```toml
-# Workspace-wide (Cargo.toml)
-freenet-stdlib = { version = "0.6.0", features = ["contract"] }
+# Workspace-wide (Cargo.toml) — track this against stdlib 0.8 once River bumps.
+freenet-stdlib = { version = "0.8", features = ["contract"] }
 freenet-scaffold = "0.2.2"
 freenet-scaffold-macro = "0.2.2"
 
@@ -252,8 +300,48 @@ freenet-stdlib = { workspace = true, features = ["net"] }
 dioxus = { version = "0.7.3", features = ["web"] }
 ```
 
-The `contract` feature is required for contract and delegate crates targeting
-`wasm32-unknown-unknown`. The `net` feature pulls in `WebApi` for the UI.
+The `contract` feature is required for contract crates targeting
+`wasm32-unknown-unknown`; use the `delegate` feature for delegate crates.
+The `net` feature pulls in `WebApi` for the UI.
+
+### TypeScript UI
+
+For UIs built with TypeScript + Vite (Option B in Phase 3), depend on the
+matching `@freenetorg/freenet-stdlib` release:
+
+```json
+{
+  "dependencies": {
+    "@freenetorg/freenet-stdlib": "^0.2.0"
+  },
+  "devDependencies": {
+    "vite": "^6.0",
+    "typescript": "^5.0",
+    "sass": "^1.0"
+  }
+}
+```
+
+The TS package v0.2.0 brought the API to parity with the Rust client:
+`FreenetWsApi` with **promise-based** `get`/`put`/`update`/`subscribe`/
+`disconnect` (`await api.X(...)`), full `ResponseHandler` including
+`onContractNotFound`/`onSubscribeResponse`/`onClose`, inbound
+`ReassemblyBuffer`, and transparent outbound chunking for payloads
+>512 KB. Callbacks still fire alongside promises for backward
+compatibility; the default request timeout is 30 s. See
+`references/ui-patterns.md` for the full pattern and a warning about the
+private `sendRequest` cast used for delegate messages until a public
+builder lands.
+
+### Security: removed encryption defaults
+
+stdlib v0.6.0 (PR #75) **removed** the public constants `DEFAULT_CIPHER`
+and `DEFAULT_NONCE` to close a CVE-class issue (world-known keys leaked
+into any binary that imported them). Delegates that previously used these
+must now generate random values per session — e.g.
+`let key: [u8; 32] = rand::random(); let nonce: [u8; 24] = rand::random();`.
+Code still referencing the old constants will fail to compile against
+stdlib 0.6 or newer.
 
 ---
 

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -1,6 +1,6 @@
 # Build System
 
-Freenet dApps use `cargo-make` for orchestrating builds across contracts, delegates, and UI.
+Freenet dApps can use `cargo-make` (Makefile.toml) or plain `Makefile` for orchestrating builds across contracts, delegates, and UI. River uses cargo-make; freenet-microblogging uses a plain Makefile with Vite.
 
 ## Prerequisites
 
@@ -120,7 +120,7 @@ publish     = false
 [workspace]
 
 [dependencies]
-freenet-stdlib = { version = "=0.6.0", features = ["contract"] }
+freenet-stdlib = { version = "=0.8.0", features = ["contract"] }
 ml-dsa         = "=0.0.4"
 chrono         = { version = "=0.4.40", default-features = false }
 serde          = { version = "=1.0.219", features = ["derive"] }
@@ -252,7 +252,8 @@ resolver = "2"
 [workspace.dependencies]
 # Mirror River's pinned versions; bump together when upgrading. Check
 # https://github.com/freenet/river/blob/main/Cargo.toml before pinning.
-freenet-stdlib = { version = "0.6.0", features = ["contract"] }
+# stdlib bumped to 0.8 to track current freenet-stdlib release (0.6→0.7→0.8).
+freenet-stdlib = { version = "0.8", features = ["contract"] }
 freenet-scaffold = "0.2.2"
 freenet-scaffold-macro = "0.2.2"
 serde = { version = "1", features = ["derive"] }
@@ -518,6 +519,126 @@ cargo make sign-webapp            # Sign for deployment
 cargo make publish                # Publish to Freenet
 ```
 
+## Plain Makefile (TypeScript + Vite)
+
+For TypeScript UIs, a plain `Makefile` is simpler than cargo-make:
+
+```makefile
+PROJECT_DIR := $(abspath .)
+WEB_DIR := $(PROJECT_DIR)/web
+CONTRACT_DIR := $(PROJECT_DIR)/contracts/my-contract
+DELEGATE_DIR := $(PROJECT_DIR)/delegates/my-delegate
+
+# Require CARGO_TARGET_DIR to avoid path assumptions
+ifeq ($(CARGO_TARGET_DIR),)
+$(error CARGO_TARGET_DIR is not set)
+endif
+
+build: contract delegate publish-contract publish-delegate webapp publish-webapp
+
+# --- Contract ---
+contract:
+	cd $(CONTRACT_DIR) && fdev build
+	# Extract contract key hash for the webapp
+	hash=$$(fdev inspect $(CONTRACT_DIR)/build/freenet/my_contract key \
+	    | grep 'code key:' | cut -d' ' -f3) && \
+	    printf '%s' $$hash > $(WEB_DIR)/model_code_hash.txt
+
+publish-contract:
+	fdev publish \
+	    --code $(CARGO_TARGET_DIR)/wasm32-unknown-unknown/release/my_contract.wasm \
+	    contract \
+	    --state $(CONTRACT_DIR)/initial_state.json
+
+# --- Delegate ---
+delegate:
+	cd $(DELEGATE_DIR) && fdev build --package-type delegate
+
+publish-delegate:
+	# 1. Publish and capture key (strip ANSI escape codes from fdev output)
+	key=$$(fdev publish \
+	    --code $(DELEGATE_DIR)/build/freenet/my_delegate \
+	    delegate 2>&1 \
+	    | sed 's/\x1b\[[0-9;]*m//g' \
+	    | grep -o 'key: [^ ,]*' | head -1 | cut -d' ' -f2) && \
+	    printf '%s' $$key > $(WEB_DIR)/delegate_key.txt && \
+	    node -e "const bs58=require('bs58'); \
+	        console.log(JSON.stringify(Array.from(bs58.default.decode('$$key'))))" \
+	        > $(WEB_DIR)/delegate_key_bytes.json
+	# 2. Compute code_hash from raw WASM (BLAKE3)
+	code_hash_hex=$$(b3sum --no-names \
+	    $(CARGO_TARGET_DIR)/wasm32-unknown-unknown/release/my_delegate.wasm) && \
+	    node -e "console.log(JSON.stringify(Array.from( \
+	        Buffer.from('$$code_hash_hex'.trim(),'hex'))))" \
+	        > $(WEB_DIR)/delegate_code_hash_bytes.json
+
+# --- Webapp ---
+webapp:
+	cd $(WEB_DIR) && npm install && npm run build && fdev build
+
+publish-webapp:
+	fdev publish \
+	    --code $(CARGO_TARGET_DIR)/wasm32-unknown-unknown/release/my_web.wasm \
+	    contract \
+	    --state $(WEB_DIR)/build/freenet/contract-state
+
+# --- Utilities ---
+run-node:
+	RUST_BACKTRACE=1 RUST_LOG=freenet=debug,info \
+	    freenet local --ws-api-address 127.0.0.1
+
+clean-node:
+	rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet
+	rm -rf ~/Library/Caches/The-Freenet-Project-Inc.freenet
+
+clean:
+	cargo clean
+	rm -rf $(WEB_DIR)/dist $(WEB_DIR)/build
+	rm -f $(WEB_DIR)/model_code_hash.txt $(WEB_DIR)/delegate_key*.json
+```
+
+## fdev Publish: Contracts vs Delegates (CRITICAL)
+
+The `fdev publish` command works **differently** for contracts and delegates:
+
+| | Contracts | Delegates |
+|---|---|---|
+| `--code` input | **Raw WASM** from `target/wasm32-unknown-unknown/release/` | **Packaged file** from `build/freenet/` (created by `fdev build --package-type delegate`) |
+| Subcommand | `contract` | `delegate` |
+| State | `--state initial_state.json` | None |
+
+```bash
+# Contract: raw WASM file
+fdev publish --code target/wasm32-unknown-unknown/release/my_contract.wasm \
+    contract --state initial_state.json
+
+# Delegate: packaged file (NOT raw WASM)
+fdev publish --code delegates/my-delegate/build/freenet/my_delegate \
+    delegate
+```
+
+Using the wrong file type causes silent failures or cryptic errors.
+
+### ANSI Escape Code Stripping
+
+`fdev` output contains ANSI color codes. When piping to `grep` or capturing keys, strip them:
+
+```bash
+fdev publish ... 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -o 'key: [^ ,]*'
+```
+
+### clean-node Pattern
+
+When republishing contracts/delegates with the same key (common during development), the node may reject the update. Delete node data between iterations:
+
+```bash
+# macOS
+rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet
+
+# Linux
+rm -rf ~/.local/share/freenet/
+```
+
 ## Contract WASM Optimization
 
 For smaller WASM files, add to contract's Cargo.toml:
@@ -760,6 +881,7 @@ if error_msg.contains("GET operation timed out") {
 }
 ```
 
-## River Build Reference
+## Reference Projects
 
-See [River's Makefile.toml](https://github.com/freenet/river/blob/main/Makefile.toml) for a complete build configuration.
+- [River's Makefile.toml](https://github.com/freenet/river/blob/main/Makefile.toml) — cargo-make with Dioxus UI
+- [freenet-microblogging's Makefile](https://github.com/freenet/freenet-microblogging/blob/main/Makefile) — plain Make with TypeScript + Vite UI

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -18,7 +18,9 @@ impl DelegateInterface for MyDelegate {
     /// Process inbound messages, return outbound messages
     fn process(
         parameters: Parameters<'static>,
-        attested: Option<&'static [u8]>,
+        // Identifies the caller (web app or peer delegate). Replaced the old
+        // `attested: Option<&[u8]>` in stdlib v0.5. See "Inter-delegate messaging".
+        origin: Option<MessageOrigin>,
         message: InboundDelegateMsg,
     ) -> Result<Vec<OutboundDelegateMsg>, DelegateError>;
 }
@@ -80,12 +82,14 @@ pub enum OutboundDelegateMsg {
 
 ## Secret Storage Pattern
 
+> **API drift note (stdlib v0.5+):** The snippets below illustrate the *pre-v0.5* secrets-by-message API (`SetSecretRequest` / `GetSecretRequest` / `GetSecretResponse` as `InboundDelegateMsg` / `OutboundDelegateMsg` variants), plus the old `attested: Option<&[u8]>` context blob. In v0.5+ secrets are accessed **synchronously** via `DelegateCtx::get_secret` / `set_secret` / `has_secret` / `remove_secret`, and context attestation is the `Option<MessageOrigin>` discussed in [Inter-delegate messaging](#inter-delegate-messaging). The conceptual pattern (origin-namespaced keys, async context with pending ops) still applies — only the call shape changed. Update against `freenet-stdlib/rust/src/delegate_interface.rs` when porting to current stdlib.
+
 Delegates use secret storage for private, persistent data:
 
 ```rust
 fn process(
     parameters: Parameters<'static>,
-    attested: Option<&'static [u8]>,
+    origin: Option<MessageOrigin>,
     message: InboundDelegateMsg,
 ) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {
     match message {
@@ -107,6 +111,7 @@ fn process(
             Ok(vec![OutboundDelegateMsg::ApplicationMessage(...)])
         }
 
+        // Wildcard arm required since stdlib v0.6 marked this enum #[non_exhaustive]
         _ => Ok(vec![])
     }
 }
@@ -132,6 +137,27 @@ impl ChatDelegateKey {
 // Keys are stored as: "abc123:user_data"
 // Each app (origin) has isolated storage
 ```
+
+## Inter-delegate messaging
+
+Starting in stdlib v0.5, `DelegateInterface::process()` receives an `Option<MessageOrigin>` (which replaced the older `attested: Option<&[u8]>` parameter). When one delegate sends an `ApplicationMessage` to another delegate via `OutboundDelegateMsg::SendDelegateMessage`, the runtime attests the caller's identity so the receiver can make authorization decisions.
+
+The `MessageOrigin` enum has two variants today:
+
+- `MessageOrigin::WebApp(ContractInstanceId)` — the message was sent by a web application backed by the given contract.
+- `MessageOrigin::Delegate(DelegateKey)` — the message was sent by another delegate. The carried key is the runtime-attested identity of the calling delegate.
+
+```rust
+match origin {
+    Some(MessageOrigin::WebApp(id)) => { /* called from contract UI */ }
+    Some(MessageOrigin::Delegate(id)) => { /* called from another delegate, verify id whitelist */ }
+    None => { /* unattested — treat as untrusted */ }
+    // Wildcard arm required since stdlib v0.6 marked this enum #[non_exhaustive]
+    _ => { /* future variants */ }
+}
+```
+
+**Security note:** Do not trust `MessageOrigin::Delegate` for sensitive operations unless you whitelist the caller's `DelegateKey`. Per the stdlib docs, an inter-delegate message *replaces* rather than composes with any inherited `WebApp` origin the calling delegate may itself hold — the receiver sees only `Delegate(caller_key)` for the duration of the call and does not gain contract access on behalf of any web app the caller was acting for. Authorize on the calling delegate's identity alone.
 
 ## Async Operation Pattern
 
@@ -177,6 +203,7 @@ fn process(..., message: InboundDelegateMsg) -> Result<Vec<OutboundDelegateMsg>,
                 // Process and send result to UI
             }
         }
+        // Wildcard arm required since stdlib v0.6 marked this enum #[non_exhaustive]
         _ => {}
     }
 
@@ -224,6 +251,7 @@ fn process(...) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {
                 )])
             }
         }
+        // Wildcard arm required since stdlib v0.6 marked this enum #[non_exhaustive]
         _ => Ok(vec![])
     }
 }
@@ -277,6 +305,49 @@ fn encrypt_for_recipient(
      │ StoreConfirm │                   │
      │◀─────────────│                   │
 ```
+
+## DelegateKey Anatomy (CRITICAL)
+
+A `DelegateKey` has **two separate fields**, not one. Confusing them causes silent failures where the node can't find the delegat
+```
+DelegateKey {
+    key:       BLAKE3(code_hash || params)   // the lookup key used by the node
+    code_hash: BLAKE3(raw_wasm_bytes)        // hash of the raw WASM file
+}
+```
+
+### How to Compute Each Field
+
+- **`code_hash`**: `BLAKE3` of the raw `.wasm` file bytes. Compute with `b3sum`:
+  ```bash
+  b3sum --no-names target/wasm32-unknown-unknown/release/my_delegate.wasm
+  ```
+
+- **`key`**: `BLAKE3(code_hash_bytes || params_bytes)`. When params are empty, this is `BLAKE3(code_hash_bytes)` — NOT the same as `code_hash` (which is `BLAKE3(wasm_bytes)`).
+
+### The Double-Hashing Bug
+
+**Bug pattern:** Using `CodeHash::from_code(bytes)` on bytes that are already a hash. `from_code()` runs BLAKE3 on its input. If the input is already a BLAKE3 hash, you get `BLAKE3(BLAKE3(wasm))` instead of `BLAKE3(wasm)`.
+
+This happened in `freenet-stdlib/rust/src/delegate_interface.rs` during FlatBuffers deserialization — the `code_hash` field was already hashed bytes, but the deserialization code re-hashed them.
+
+**Fix:** Use `CodeHash::new(bytes)` (wraps raw bytes) instead of `CodeHash::from_code(bytes)` (hashes then wraps) when working with bytes that are already a hash.
+
+**When building delegate messages from TypeScript**, you must pass BOTH fields correctly:
+
+```typescript
+// DelegateKeyT takes (key_bytes, code_hash_bytes) — they are DIFFERENT
+const delegateKey = new DelegateKeyT(delegateKeyBytes, delegateCodeHashBytes);
+```
+
+If you pass `keyBytes` for both fields (or `codeHashBytes` for both), the node won't find the delegate.
+
+### Pre-Publishing Checklist
+
+1. Compute `code_hash` with `b3sum` on the raw WASM
+2. Capture the full `key` from `fdev publish` output (strip ANSI: `sed 's/\x1b\[[0-9;]*m//g'`)
+3. Pre-decode both to byte arrays for the UI (base58 → JSON for key, hex → JSON for code_hash)
+4. Verify both are injected separately in your build config
 
 ## Delegate WASM Upgrade & Secret Migration
 

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -1,6 +1,6 @@
 # UI Patterns
 
-The UI is the interaction layer that connects to the Freenet Kernel via WebSocket/HTTP. River uses Dioxus (Rust), but you can use any web framework.
+The UI is the interaction layer that connects to the Freenet Kernel via WebSocket/HTTP. River uses Dioxus (Rust), but you can use any web framework. This document covers both Dioxus and TypeScript + Vite approaches.
 
 ## Architecture Overview
 
@@ -96,9 +96,10 @@ edition = "2021"
 
 [dependencies]
 # Mirror River's pinned versions; see https://github.com/freenet/river/blob/main/ui/Cargo.toml
+# stdlib bumped to 0.8 to track current freenet-stdlib release.
 dioxus = { version = "0.7.3", features = ["web"] }
 dioxus-free-icons = { version = "0.10.0", features = ["font-awesome-solid"] }
-freenet-stdlib = { version = "0.6.0", features = ["net"] }
+freenet-stdlib = { version = "0.8", features = ["net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 web-sys = { version = "0.3", features = ["WebSocket", "MessageEvent", "Window", "Location"] }
@@ -499,6 +500,328 @@ async fn start_sync() {
     log::info!("Running in no-sync mode");
 }
 ```
+
+---
+
+## TypeScript + Vite Approach
+
+For teams more comfortable with TypeScript, Vite provides fast iteration with HMR, SCSS support, and familiar npm tooling. The `@freenetorg/freenet-stdlib` TypeScript package provides the WebSocket API with FlatBuffers serialization.
+
+### Vite Configuration
+
+The key trick: inject contract hashes and delegate key bytes as compile-time constants via Vite `define`. These are computed during `make build` and written to JSON/text files.
+
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+function readFileOrDefault(filename: string, fallback: string): string {
+  const filePath = resolve(__dirname, filename);
+  return existsSync(filePath) ? readFileSync(filePath, "utf-8").trim() : fallback;
+}
+
+export default defineConfig({
+  // If using a local freenet-stdlib checkout (common during development):
+  resolve: {
+    alias: {
+      "@freenetorg/freenet-stdlib/client-request": resolve(
+        __dirname, "../../freenet-stdlib/typescript/src/client-request.ts"
+      ),
+      "@freenetorg/freenet-stdlib/common": resolve(
+        __dirname, "../../freenet-stdlib/typescript/src/common.ts"
+      ),
+      "@freenetorg/freenet-stdlib": resolve(
+        __dirname, "../../freenet-stdlib/typescript/src/index.ts"
+      ),
+    },
+  },
+  define: {
+    // Contract key (base58 string) — written by `fdev inspect ... key`
+    __MODEL_CONTRACT__: JSON.stringify(
+      readFileOrDefault("model_code_hash.txt", "DEV_MODE_NO_CONTRACT_HASH")
+    ),
+    // Delegate key bytes (pre-decoded from base58 to number[])
+    __DELEGATE_KEY_BYTES__: readFileOrDefault("delegate_key_bytes.json", "[]"),
+    // Delegate code_hash bytes (BLAKE3 of raw WASM, as number[])
+    __DELEGATE_CODE_HASH_BYTES__: readFileOrDefault("delegate_code_hash_bytes.json", "[]"),
+  },
+  // CRITICAL: relative base path for sandboxed iframe serving
+  base: "./",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+});
+```
+
+**Why `base: "./"` is critical:** Freenet serves webapp files inside a sandboxed iframe at a path like `/v1/contract/web/{CONTRACT_ID}/`. Absolute paths (`/assets/...`) would resolve against the node root and 404. Relative paths (`./assets/...`) resolve correctly within the iframe.
+
+### TypeScript Type Declarations
+
+Declare the compile-time constants so TypeScript doesn't complain:
+
+```typescript
+// src/vite-env.d.ts
+declare const __MODEL_CONTRACT__: string;
+declare const __DELEGATE_KEY_BYTES__: number[];
+declare const __DELEGATE_CODE_HASH_BYTES__: number[];
+```
+
+### WebSocket Connection (TypeScript)
+
+Use `FreenetWsApi` from the stdlib TypeScript package. It handles FlatBuffers serialization/deserialization automatically.
+
+```typescript
+import {
+  FreenetWsApi,
+  ContractKey,
+  GetRequest,
+  GetResponse,
+  UpdateRequest,
+  UpdateResponse,
+  UpdateNotification,
+  UpdateData,
+  UpdateDataType,
+  DeltaUpdate,
+  SubscribeRequest,
+  PutResponse,
+  DelegateResponse,
+  HostError,
+  ResponseHandler,
+} from "@freenetorg/freenet-stdlib";
+
+// Build WebSocket URL from current location (works in sandbox iframe)
+const wsUrl = new URL(`ws://${location.host}/v1/contract/command`);
+
+const handler: ResponseHandler = {
+  onContractPut: (response: PutResponse) => { /* fired on put completion */ },
+  onContractGet: (response: GetResponse) => {
+    // Decode state bytes → JSON → your app types
+    const decoder = new TextDecoder("utf8");
+    const json = decoder.decode(Uint8Array.from(response.state));
+    const state = JSON.parse(json);
+    // Update your UI...
+  },
+  onContractUpdate: (response: UpdateResponse) => { /* fired on update completion */ },
+  onContractUpdateNotification: (notification: UpdateNotification) => {
+    // Handle delta updates from subscriptions
+    const updateData = notification.update as UpdateData;
+    if (updateData?.updateDataType === UpdateDataType.DeltaUpdate) {
+      const delta = updateData.updateData as { delta: number[] };
+      const json = new TextDecoder().decode(Uint8Array.from(delta.delta));
+      // Parse and apply delta...
+    }
+  },
+  // Added in stdlib v0.2.0: fired when a GET targets a missing contract instance
+  onContractNotFound: (instanceId) => {
+    console.warn("[freenet] Contract not found:", instanceId);
+  },
+  // Added in stdlib v0.2.0: fired on SUBSCRIBE confirmation (subscribed flag = success)
+  onSubscribeResponse: (key, subscribed) => {
+    console.log("[freenet] Subscribe:", key.encode(), "ok=", subscribed);
+  },
+  onDelegateResponse: (response: DelegateResponse) => { /* delegate result */ },
+  onErr: (err: HostError) => {
+    console.error("[freenet] Error:", err.cause);
+  },
+  onOpen: () => {
+    console.log("[freenet] Connected");
+    // Now safe to send GET, SUBSCRIBE, etc.
+  },
+  // Added in stdlib v0.2.0: WebSocket close. All pending promises will already have rejected.
+  onClose: (code, reason) => {
+    console.warn("[freenet] Disconnected:", code, reason);
+    // App layer decides reconnect strategy — SDK does NOT auto-reconnect.
+  },
+};
+
+// CRITICAL: Pass empty string as auth token.
+// In the sandbox iframe, cookie reading is blocked. The shell page handles auth
+// via the postMessage bridge. Passing "" tells FreenetWsApi to skip cookie reading.
+const api = new FreenetWsApi(wsUrl, handler, "");
+```
+
+### Building ContractKey from Hash
+
+The contract hash (base58 string) from `fdev inspect` needs to be converted to a `ContractKey`:
+
+```typescript
+const contractHash = __MODEL_CONTRACT__; // injected by Vite
+const keyFromId = ContractKey.fromInstanceId(contractHash);
+const instanceBytes = keyFromId.bytes();
+// ContractKey needs both instance bytes and code hash bytes.
+// When no parameters are used, they're the same.
+const contractKey = new ContractKey(instanceBytes, instanceBytes);
+```
+
+### Contract Operations
+
+stdlib TS v0.2.0 made `get`, `put`, `update`, `subscribe`, and `disconnect` **promise-based**. They resolve with the typed response, reject on timeout (default 30s), connection close, or host error. The legacy callbacks in `ResponseHandler` still fire for the same response — both APIs coexist for backward compatibility.
+
+```typescript
+// GET — fetch current state (await + try/catch)
+try {
+  const getReq = new GetRequest(contractKey, true);
+  const response = await api.get(getReq);
+  const json = new TextDecoder().decode(Uint8Array.from(response.state));
+  const state = JSON.parse(json);
+  // ...use state
+} catch (err) {
+  console.error("[freenet] GET failed:", err); // timeout / not-found / closed
+}
+
+// SUBSCRIBE — receive real-time updates (promise resolves on SubscribeResponse)
+try {
+  await api.subscribe(new SubscribeRequest(contractKey, []));
+} catch (err) {
+  console.error("[freenet] SUBSCRIBE failed:", err);
+}
+
+// UPDATE — send a delta
+const encoder = new TextEncoder();
+const deltaBytes = encoder.encode(JSON.stringify(myDelta));
+const delta = new DeltaUpdate(Array.from(deltaBytes));
+const update = new UpdateData(UpdateDataType.DeltaUpdate, delta);
+try {
+  await api.update(new UpdateRequest(contractKey, update));
+} catch (err) {
+  console.error("[freenet] UPDATE failed:", err);
+}
+```
+
+### Large state handling (streaming)
+
+stdlib TS v0.2.0 ports the Rust streaming protocol. You don't need to call any special API — chunking and reassembly are transparent — but you should know the limits.
+
+**Outbound (request side):**
+- Any serialized request larger than `CHUNK_THRESHOLD = 512 KB` is automatically split into sequential `StreamChunk` messages of `CHUNK_SIZE = 256 KB` by `sendRequest()`.
+- A 600 KB `PutRequest` goes over the wire as multiple chunks; the receiver reassembles it. Your code just does `await api.put(req)` — no opt-in flag.
+
+**Inbound (response side):**
+- The SDK reassembles incoming chunked responses inside `ReassemblyBuffer`. If you ever need raw control (e.g., a custom transport), import the buffer directly:
+  ```typescript
+  import { ReassemblyBuffer } from "@freenetorg/freenet-stdlib"; // or "@freenetorg/freenet-stdlib/streaming"
+  ```
+- Limits hard-coded in v0.2.0: per-stream TTL **60 s**, max **8 concurrent streams**, max **256 chunks/stream**. Out-of-order chunks are tolerated; duplicates and overflows are rejected with `StreamError`.
+
+**When this matters:** large media uploads, snapshot-style state initialization, multi-MB contract codes. Below 512 KB the protocol is invisible.
+
+### Delegate Communication (TypeScript)
+
+Sending messages to delegates from TypeScript requires building FlatBuffers objects manually. The public API only exposes high-level types; you need internal `-T` types (the mutable FlatBuffers table classes) that have `pack()` methods.
+
+**Dynamic imports are required** because these internal types aren't part of the main export:
+
+```typescript
+import { FreenetWsApi, DelegateRequest } from "@freenetorg/freenet-stdlib";
+
+export async function sendDelegateMessage(
+  api: FreenetWsApi,
+  delegateKeyBytes: number[],
+  delegateCodeHash: number[],
+  message: object
+): Promise<void> {
+  const payload = Array.from(new TextEncoder().encode(JSON.stringify(message)));
+
+  // Import internal FlatBuffers table types (resolved by Vite aliases)
+  // @ts-ignore — resolved by Vite alias at build time
+  const { ApplicationMessageT } = await import("@freenetorg/freenet-stdlib/common");
+  // @ts-ignore — resolved by Vite alias at build time
+  const {
+    ClientRequestT,
+    ClientRequestType,
+    ApplicationMessagesT,
+    DelegateKeyT,
+    DelegateRequestType,
+    InboundDelegateMsgT,
+    InboundDelegateMsgType,
+  } = await import("@freenetorg/freenet-stdlib/client-request");
+
+  // Build the message chain
+  const appMsg = new ApplicationMessageT(payload, [], false);
+  const inbound = new InboundDelegateMsgT(
+    InboundDelegateMsgType.common_ApplicationMessage,
+    appMsg
+  );
+
+  // DelegateKey has TWO fields: key bytes AND code_hash bytes
+  const delegateKey = new DelegateKeyT(delegateKeyBytes, delegateCodeHash);
+
+  const appMessages = new ApplicationMessagesT(delegateKey, [], [inbound]);
+  const delegateReq = new DelegateRequest(
+    DelegateRequestType.ApplicationMessages,
+    appMessages
+  );
+  const clientReq = new ClientRequestT(
+    ClientRequestType.DelegateRequest,
+    delegateReq
+  );
+
+  // sendRequest is a private method — access via cast
+  (api as any).sendRequest(clientReq);
+}
+```
+
+> **Warning — unstable API:** `(api as any).sendRequest(...)` reaches into a private SDK method because the public delegate-request builder is not yet stable in stdlib v0.2.0. This cast may break on any minor SDK bump. Track [freenet-stdlib](https://github.com/freenet/freenet-stdlib) for a public `api.sendDelegateMessage()` (or equivalent) before relying on this in production.
+
+### Parsing Delegate Responses
+
+```typescript
+import { DelegateResponse } from "@freenetorg/freenet-stdlib";
+
+export function parseDelegateResponse(response: DelegateResponse): object[] {
+  const results: object[] = [];
+  if (!response.values) return results;
+
+  for (const outbound of response.values) {
+    // OutboundDelegateMsgType.common_ApplicationMessage = 1
+    if (outbound.inboundType !== 1) continue;
+
+    const msg = outbound.inbound as { payload?: number[] } | null;
+    if (!msg?.payload?.length) continue;
+
+    try {
+      const bytes = new Uint8Array(msg.payload);
+      const json = new TextDecoder().decode(bytes);
+      results.push(JSON.parse(json));
+    } catch (e) {
+      console.warn("Failed to parse delegate payload:", e);
+    }
+  }
+
+  return results;
+}
+```
+
+### Pre-Decoded Key Bytes Pattern
+
+The browser sandbox can't reliably run base58 decoding libraries. Pre-decode keys at build time and inject as JSON arrays:
+
+```bash
+# In your Makefile publish-identity target:
+# 1. Publish delegate, capture base58 key
+key=$(fdev publish --code ... delegate 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -o 'key: [^ ,]*' | head -1 | cut -d' ' -f2)
+
+# 2. Decode base58 → JSON byte array (requires bs58 npm package)
+node -e "const bs58=require('bs58');console.log(JSON.stringify(Array.from(bs58.default.decode('$key'))))" > delegate_key_bytes.json
+
+# 3. Compute code_hash from raw WASM (BLAKE3)
+code_hash_hex=$(b3sum --no-names target/wasm32-unknown-unknown/release/my_delegate.wasm)
+node -e "const h='$code_hash_hex'.trim();console.log(JSON.stringify(Array.from(Buffer.from(h,'hex'))))" > delegate_code_hash_bytes.json
+```
+
+Vite injects these as `__DELEGATE_KEY_BYTES__` and `__DELEGATE_CODE_HASH_BYTES__` compile-time constants.
+
+### Microblogging Reference
+
+See [freenet-microblogging](https://github.com/freenet/freenet-microblogging) for a complete TypeScript + Vite implementation:
+- `web/src/freenet-api.ts` — FreenetWsApi wrapper with GET/UPDATE/SUBSCRIBE
+- `web/src/delegate-api.ts` — Delegate FlatBuffers message building
+- `web/src/identity.ts` — Identity management (delegate + in-memory fallback)
+- `web/vite.config.ts` — Build-time key injection
+- `Makefile` — Full build pipeline
 
 ## River UI Reference
 

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -346,9 +346,17 @@ NodeDiagnosticsConfig {
     include_network_info: bool,        // Active connections, peer list
     include_subscriptions: bool,       // Active subscriptions
     contract_keys: Vec<ContractKey>,   // Specific contracts (empty = all)
-    include_system_metrics: bool,      // Connection count, seeding contracts
+    include_system_metrics: bool,      // Connection count, hosting contracts
     include_detailed_peer_info: bool,  // Full peer details
     include_subscriber_peer_ids: bool, // Peer IDs of subscribers per contract
+}
+```
+
+**Wire-format change (stdlib v0.7.0):** `NodeDiagnosticsResponse.contract_states` is now `HashMap<String, ContractState>` where the key is the Base58-encoded `ContractKey::Display` form (the `instance` field, not the full struct). Previously it was `HashMap<ContractKey, ContractState>` but that serialization broke JSON because the key was a struct. To map back to a typed `ContractKey`, decode the Base58 string and reconstruct. This is a bidirectional bincode break — match node and tooling versions.
+
+```rust
+for (key_str, state) in diag.contract_states.iter() {
+    // key_str is the Base58 ContractKey instance id
 }
 ```
 


### PR DESCRIPTION
Closes #31.

## Summary

- Bumps the `dapp-builder` and `local-dev` skills to track `freenet-stdlib` v0.6 → v0.8 (Rust) and `@freenetorg/freenet-stdlib` v0.1 → v0.2.0 (TypeScript), so Rust and TS examples copied from the skill compile and run against the current node.
- Adds a first-class **TypeScript + Vite** UI option (Phase 3 / Option B) alongside the existing Dioxus path, unblocking web developers who don't use Rust UI frameworks.
- Captures three upstream wire/API breaks that previously produced silent failures or compile errors: `MessageOrigin` (PR #65), `#[non_exhaustive]` wire enums (PR #66), `NodeDiagnosticsResponse.contract_states` Base58 keys (PR #70).
- Documents the security removal of `DEFAULT_CIPHER` / `DEFAULT_NONCE` (PR #75) and the `seeding` → `hosting` terminology rename (PR #64).

Version: `marketplace.json` 1.2.0 → **1.3.0** (MINOR — new content + breaking-change docs, no skill-API breaks).

## What changed

### `dapp-builder/SKILL.md`
- **Phase 3 split into Option A (Dioxus) and Option B (TypeScript + Vite)** with parallel implementation steps. Project Structure Templates now show both Dioxus and TS+Vite layouts.
- **Key Dependencies** section: bumped Rust pin `0.6.0` → `0.8` (workspace + UI crate). Added a note on River's lag (River pins `0.6.0`; downstream code that links stdlib directly needs `0.8` *and* the new match wildcards / random cipher generation).
- New **TypeScript UI** subsection covering the `@freenetorg/freenet-stdlib@0.2.0` surface: `FreenetWsApi`, promise-based methods, full `ResponseHandler` callbacks, inbound `ReassemblyBuffer`, outbound chunking, 30 s default timeout.
- New **Security: removed encryption defaults** subsection: stdlib v0.6.0 (PR #75) removed the world-known `DEFAULT_CIPHER` / `DEFAULT_NONCE` constants; delegates must now generate random values per session (`rand::random()`).

### `dapp-builder/references/ui-patterns.md`
- New **TypeScript + Vite Approach** section: Vite config with subpath aliases (`@freenetorg/freenet-stdlib/{client-request,common,host-response}`), compile-time injection of contract hashes and delegate key bytes via `define`, TS type declarations for the injected globals.
- New **WebSocket Connection (TypeScript)** subsection with the canonical `FreenetWsApi` setup using the v0.2.0 `ResponseHandler` (including the new `onContractNotFound`, `onSubscribeResponse`, `onClose` callbacks).
- **Contract operations** converted to the promise-based API (`await api.get/put/update/subscribe(...)` + `try/catch`) with a note that callbacks still fire alongside promises for backward compatibility.
- New **Large state handling (streaming)** subsection: `CHUNK_THRESHOLD = 512 KB`, `CHUNK_SIZE = 256 KB`, `ReassemblyBuffer`, per-stream TTL 60 s, max 8 concurrent streams, max 256 chunks/stream.
- **Delegate Communication (TypeScript)** section retained, with a new **warning above the `(api as any).sendRequest(...)` cast** flagging it as a private SDK method that may break on any minor SDK bump until a public delegate-message builder lands upstream.
- Bumped Cargo.toml stdlib pin `0.6.0` → `0.8`.

### `dapp-builder/references/delegate-patterns.md`
- **Renamed `attested: Option<&'static [u8]>` → `origin: Option<MessageOrigin>`** in `DelegateInterface::process()` examples (stdlib v0.5 breaking change). Existing callers will not compile against current stdlib without this rename.
- New **Inter-delegate messaging** section covers `MessageOrigin::WebApp(ContractInstanceId)` vs `MessageOrigin::Delegate(DelegateKey)` (PR #65), with a whitelist-based authorization pattern and the security note that an inter-delegate message *replaces* (does not compose with) any inherited `WebApp` origin.
- **Wildcard `_ => {}` arms added to every `match` over `InboundDelegateMsg`** with comments noting the `#[non_exhaustive]` requirement from stdlib v0.6.0 (PR #66). Without these, code fails to compile.
- New **API drift note** at the top of the Secret Storage section: the pre-v0.5 secrets-by-message pattern (`SetSecretRequest`/`GetSecretRequest`/`GetSecretResponse` as message variants) is now `DelegateCtx::get_secret/set_secret/has_secret/remove_secret` accessed synchronously. The conceptual patterns (origin-namespaced keys, async context with pending ops) still apply.

### `dapp-builder/references/build-system.md`
- **TypeScript + Vite** Makefile / dependency block added alongside the Rust + cargo-make flow.
- Workspace stdlib pin bumped `0.6.0` → `0.8`.

### `local-dev/SKILL.md`
- `NodeDiagnosticsConfig` comment: **"seeding contracts" → "hosting contracts"** to match the stdlib terminology rename (PR #64).
- New **wire-format note** on `NodeDiagnosticsResponse.contract_states`: now `HashMap<String, ContractState>` with Base58-encoded `ContractKey::Display` keys (PR #70, v0.7.0). Bidirectional bincode break — node and tooling versions must match.

### `marketplace.json` + `CHANGELOG.md`
- Plugin version bumped 1.2.0 → 1.3.0.
- `CHANGELOG.md` records every delta with cross-references to the upstream PRs that caused the drift.

## Out of scope (intentionally deferred)

- **Full rewrite of `delegate-patterns.md` Secret Storage example to the v0.5+ `DelegateCtx` API.** Flagged via the API drift note. A separate PR can rewrite the example end-to-end against current stdlib (current snippets remain conceptually correct, just structurally older).
- **`freenet-scaffold` / `freenet-scaffold-macro` pins.** Left at River's `0.2.2`. These live in a different repo and have not had matching releases requiring a bump.
- **Auto-reconnect strategy for `FreenetWsApi`.** The SDK intentionally exposes `onClose` and leaves reconnection to the application layer (per upstream PR #67). The skill mirrors that decision rather than inventing a recipe.
- **TypeScript 6 migration.** Pinned to TS `^5.0` because `ts-jest` is incompatible with TS 6 (upstream constraint from `freenet-stdlib/typescript`).