### PR TITLE
docs(local-dev): document gateway-isolation and fdev --port pitfalls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.2 (2026-05-26)
+- `local-dev` skill: document two silent isolation gotchas that bit users
+  during freenet-email E2E debugging (issue #24).
+  - **`--data-dir` does not isolate the gateway bootstrap list.** `freenet`
+    reads `gateways.toml` from the global config dir (`~/Library/Application
+    Support/The-Freenet-Project-Inc.Freenet/` on macOS, `~/.config/Freenet/`
+    on Linux) regardless of `--data-dir`. On a machine with an existing
+    Freenet install, a "local" test node silently dials public gateways and
+    joins the live network. New subsection documents the `HOME` override
+    workaround and a log-grep verification step.
+  - **`fdev` defaults to port 7509.** Without `--port`, `fdev publish`
+    silently targets whichever node owns 7509 — typically the system
+    service, not the test node. Surface symptom: `"Signature verification
+    failed"` on a fresh publish. New callout warns about this and the
+    common-issues table now lists both new symptoms.
+  - Replaces the misleading "Each node is fully isolated" claim with a
+    pointer to the new pitfalls section.
+
 ## 1.2.1 (2026-05-25)
 - `release` skill rewritten to use `gh workflow run release.yml --field
   version=X.Y.Z` instead of the legacy `./scripts/release.sh` invocation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
   during freenet-email E2E debugging (issue #24).
   - **`--data-dir` does not isolate the gateway bootstrap list.** `freenet`
     reads `gateways.toml` from the global config dir (`~/Library/Application
-    Support/The-Freenet-Project-Inc.Freenet/` on macOS, `~/.config/Freenet/`
+    Support/The-Freenet-Project-Inc.Freenet/` on macOS, `~/.config/freenet/`
     on Linux) regardless of `--data-dir`. On a machine with an existing
     Freenet install, a "local" test node silently dials public gateways and
     joins the live network. New subsection documents the `HOME` override

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -120,7 +120,7 @@ Use `--data-dir` for persistent isolation instead.
 of `--data-dir`:
 
 - **macOS:** `~/Library/Application Support/The-Freenet-Project-Inc.Freenet/gateways.toml`
-- **Linux:** `~/.config/Freenet/gateways.toml`
+- **Linux:** `~/.config/freenet/gateways.toml`
 
 On a machine with an existing Freenet install, a "local" test node will
 dial real public gateways (e.g. `nova.locut.us`, `vega.locut.us`) and
@@ -134,23 +134,28 @@ mkdir -p ~/iso-home/Library/Application\ Support/The-Freenet-Project-Inc.Freenet
 printf 'gateways = []\n' > ~/iso-home/Library/Application\ Support/The-Freenet-Project-Inc.Freenet/gateways.toml
 
 # Linux
-mkdir -p ~/iso-home/.config/Freenet
-printf 'gateways = []\n' > ~/iso-home/.config/Freenet/gateways.toml
+mkdir -p ~/iso-home/.config/freenet
+printf 'gateways = []\n' > ~/iso-home/.config/freenet/gateways.toml
 
-# Then launch with HOME overridden
-HOME=~/iso-home freenet network --gateway "127.0.0.1:31338,$PUBKEY" ...
+# Then launch with HOME overridden. For an isolated *gateway* node
+# (--is-gateway, no --gateway flags), expect 0 bootstrap gateways:
+HOME=~/iso-home freenet network --is-gateway --skip-load-from-network ...
+
+# For an isolated *peer* node, pass your local gateway(s) explicitly:
+HOME=~/iso-home freenet network --gateway "127.0.0.1:31337,$GATEWAY_PUBKEY" ...
 ```
 
 Note: an empty `gateways.toml` will fail with `missing field 'gateways'`.
 The file must contain `gateways = []`.
 
-**Verification:** tail the peer log for the initial-join line and confirm
-the gateway count matches your `--gateway` flag count:
+**Verification:** grep the node log for the initial-join line and confirm
+the gateway count matches what you passed:
 
 ```bash
 grep "Starting initial join procedure" "$LOG_DIR"/freenet.*.log
 # Expect: "...with N gateways" where N == number of --gateway flags
-# If N is higher, isolation is broken.
+# For an isolated gateway node (no --gateway flags), N must be 0.
+# If N is higher than expected, isolation is broken.
 ```
 
 Upstream tracking: [freenet/freenet-core#3980](https://github.com/freenet/freenet-core/issues/3980).

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -101,11 +101,78 @@ freenet network \
   --log-level debug
 ```
 
-Each node is fully isolated: persistent data in `--data-dir`, logs in `--log-dir`.
+Persistent data lives in `--data-dir` and logs in `--log-dir`, but the
+**gateway bootstrap list is NOT isolated** by `--data-dir` — see
+[Isolation pitfalls](#isolation-pitfalls) below before assuming the node
+is offline-only. Likewise, `fdev` defaults to port 7509 and will silently
+target whichever node owns that port (often the system service, not your
+test node).
 
 **WARNING:** Do NOT use `--id` for local dev. It creates ephemeral temp directories
 that get wiped on restart, destroying delegate secrets (signing keys, app data).
 Use `--data-dir` for persistent isolation instead.
+
+### Isolation pitfalls
+
+#### `--data-dir` does NOT isolate the gateway bootstrap list
+
+`freenet` reads `gateways.toml` from the global config directory regardless
+of `--data-dir`:
+
+- **macOS:** `~/Library/Application Support/The-Freenet-Project-Inc.Freenet/gateways.toml`
+- **Linux:** `~/.config/Freenet/gateways.toml`
+
+On a machine with an existing Freenet install, a "local" test node will
+dial real public gateways (e.g. `nova.locut.us`, `vega.locut.us`) and
+attempt NAT traversal to live peers — silently joining the public network.
+
+To fully isolate, override `HOME` so the node sees an empty gateway list:
+
+```bash
+# macOS
+mkdir -p ~/iso-home/Library/Application\ Support/The-Freenet-Project-Inc.Freenet
+printf 'gateways = []\n' > ~/iso-home/Library/Application\ Support/The-Freenet-Project-Inc.Freenet/gateways.toml
+
+# Linux
+mkdir -p ~/iso-home/.config/Freenet
+printf 'gateways = []\n' > ~/iso-home/.config/Freenet/gateways.toml
+
+# Then launch with HOME overridden
+HOME=~/iso-home freenet network --gateway "127.0.0.1:31338,$PUBKEY" ...
+```
+
+Note: an empty `gateways.toml` will fail with `missing field 'gateways'`.
+The file must contain `gateways = []`.
+
+**Verification:** tail the peer log for the initial-join line and confirm
+the gateway count matches your `--gateway` flag count:
+
+```bash
+grep "Starting initial join procedure" "$LOG_DIR"/freenet.*.log
+# Expect: "...with N gateways" where N == number of --gateway flags
+# If N is higher, isolation is broken.
+```
+
+Upstream tracking: [freenet/freenet-core#3980](https://github.com/freenet/freenet-core/issues/3980).
+
+#### `fdev` defaults to port 7509
+
+`fdev` targets `ws://127.0.0.1:7509` unless `--port` is passed. On a dev
+machine running a system Freenet service (which owns 7509), `fdev publish ...`
+without `--port` silently goes to that node, not your isolated test node.
+
+```bash
+# WRONG: silently targets whichever node owns 7509 (often the system service)
+fdev publish --code ... contract ...
+
+# RIGHT: always pass --port when targeting a non-default test node
+fdev --port 7510 publish --code ... contract ...
+```
+
+Symptom of a misdirected publish: `"Signature verification failed: signature error"`
+on a fresh publish to the test node, because the system node has stale
+contract state from a previous run signed by a different key. If you see
+this on a "fresh" test, check which node `fdev` actually hit.
 
 ### Two-node local network
 
@@ -367,7 +434,9 @@ the WebSocket connection.
 | "delegate not found in store" | Legacy delegate migration | Expected on fresh node, non-blocking |
 | "Connection reset by peer" | Browser killed WebSocket | Check if page is in background tab |
 | "peer connection dropped" on put | Publishing to live node failed | Use isolated test node (`--skip-load-from-network`) |
-| Contract not found | Not published to this node | Publish with `fdev --port {PORT}` |
+| Contract not found | Not published to this node | Publish with `fdev --port {PORT}` (see [Isolation pitfalls](#isolation-pitfalls)) |
+| "Signature verification failed" on a fresh publish | `fdev` defaulted to port 7509 and hit the system node | Pass `fdev --port {TEST_PORT}` explicitly |
+| Test node joins public network despite `--data-dir` | `gateways.toml` is read from global config, not `--data-dir` | Override `HOME` to a sandbox dir with `gateways = []` (see [Isolation pitfalls](#isolation-pitfalls)) |
 | Blank page (cached old WASM) | Mobile browser caches aggressively | Clear cache, force close browser, or use `?_v=timestamp` |
 | `sed -i` fails on macOS | BSD sed requires backup extension | Use build tools directly instead of sed |
 | `cargo make` targets Linux | Cross-compilation for web-container-tool | Build natively: `cargo build --release -p web-container-tool` |


### PR DESCRIPTION
## Problem

The `local-dev` skill claimed nodes launched with `--data-dir` are "fully isolated" — but two silent gotchas hit users debugging freenet-email E2E flows (#24):

1. **`--data-dir` does NOT isolate the gateway bootstrap list.** `freenet` reads `gateways.toml` from the global config dir (`~/Library/Application Support/The-Freenet-Project-Inc.Freenet/` on macOS, `~/.config/Freenet/` on Linux) regardless of `--data-dir`. On a dev machine with an existing Freenet install, the "local" test node silently dials public gateways (nova/vega) and joins the live network — making tests non-deterministic and the failure mode hard to attribute. Upstream tracking: freenet/freenet-core#3980.

2. **`fdev` defaults to port 7509.** Without `--port`, `fdev publish` silently targets whichever node owns 7509 — typically the launchd/systemd-managed system service, not the test node on 7510. Surface symptom: `"Signature verification failed"` on a fresh publish, because the system node has stale contract state from a previous run signed by a different key. Sends developers hunting for key-management bugs instead of port targeting mistakes.

Each gotcha cost the original reporter ~30 min before identification.

## Approach

Pure documentation change to `skills/local-dev/SKILL.md`:

- Replace the misleading "Each node is fully isolated" sentence with a pointer to a new pitfalls section.
- Add a new `### Isolation pitfalls` subsection covering both gotchas with copy-pasteable workarounds (HOME override + sandbox `gateways.toml`, `fdev --port` callout) and a grep-based verification step that uses the existing `"Starting initial join procedure with N gateways"` log line (confirmed at `crates/core/src/operations/connect.rs:1633`).
- Extend the common-issues table with both new symptoms so they're discoverable from the troubleshooting side too.

Verified the documented Linux config path (`~/.config/Freenet/`) by inspecting the live system and the `ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)` call in `crates/core/src/config.rs:1625` (APPLICATION = "Freenet", capital F).

## Testing

Documentation-only change — no executable code paths affected. CI runs the version-bump check (`.github/workflows/version-check.yml`) which requires both `marketplace.json` and `CHANGELOG.md` to be updated when skills change; both bumps are in this PR (1.2.1 → 1.2.2).

The bash snippets are reviewable at a glance (`mkdir -p` / `printf` / `HOME=... freenet network ...`); the grep verification step matches the actual log message string in freenet-core.

Closes #24

[AI-assisted - Claude]