### PR TITLE
docs(dapp-builder): gateway CSP, iframe shell, and production smoke testing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.2.2"
+    "version": "1.2.3"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,36 @@ All notable changes to this project will be documented in this file.
   smoke testing — three "only show up in production" pitfalls every Freenet
   webapp hits (issue #22, distilled from freenet/mail v0.1.0).
   - **Vendor your assets.** New "Gateway CSP: Vendor Your Assets" section in
-    `ui-patterns.md` explains the same-origin CSP, why CDN `<link>` /
-    `<script>` tags work in `dx serve` / `vite dev` but fail under
-    `fdev publish`, and the right way to bundle stylesheets / fonts into
-    your asset directory (e.g. `ui/assets/vendor/` for Dioxus). Cross-linked
-    from SKILL.md Phase 3.
+    `ui-patterns.md` explains the same-origin CSP (both `default-src` and
+    `connect-src`), why CDN `<link>` / `<script>` tags and cross-origin
+    `fetch` calls work in `dx serve` / `vite dev` but fail under
+    `fdev publish`, and the right way to bundle stylesheets / fonts under
+    `ui/assets/vendor/` (Dioxus `asset_dir` convention, matching River).
+    Cross-linked from SKILL.md Phase 3.
   - **Iframe shell + Playwright recipe.** New
     `references/production-smoke-testing.md` documents the
     `<iframe id="app">` shell architecture (with a "source of truth"
-    pointer to `freenet-core/.../server/path_handlers.rs`) and the two
-    Playwright idioms it breaks (`page.locator(...)` finds only the shell;
-    `page.goto("/")` lands on the dashboard). Includes a
-    `production-liveness.spec.ts` template that asserts WASM ran, vendored
-    CSS loaded (using `fontWeight` for stable assertion), and the browser
-    console has no CSP / network-failure errors. Cross-linked from SKILL.md
-    Phase 4.
-  - **Tooling preflight.** New section in `build-system.md` noting that the
-    gateway port is `7509` (not the legacy `50509`) and offering optional
-    `gnu-tar` flags for byte-reproducible webapp archives across
-    macOS/Linux build hosts.
+    pointer to `freenet-core/crates/core/src/server/{client_api,path_handlers}.rs`)
+    and the two Playwright idioms it breaks (`page.locator(...)` finds
+    only the shell; `page.goto("/")` lands on the dashboard). Includes a
+    `production-liveness.spec.ts` template that:
+    - waits for the shell bridge to assign `iframe#app[src]`,
+    - asserts the bundled `<h1>` mounts inside the iframe,
+    - asserts vendored CSS loaded via `getComputedStyle(...).fontWeight`
+      (more stable than `fontSize`, matching the proven
+      freenet/mail#28 assertion),
+    - filters console errors via `FATAL_CONSOLE_PATTERNS` (CSP /
+      `Refused to ...` / `net::ERR_`) so benign warnings don't flake.
+    Also includes a `playwright.config.ts` snippet and a CI bash sketch
+    that boots a local node, publishes, and exports `FREENET_BASE_URL`.
+    Cross-linked from SKILL.md Phase 4 and from `ui-patterns.md`'s "Two
+    Connection Models" section.
+  - **Tooling preflight.** New section in `build-system.md` noting that
+    the gateway port is `7509` (older docs reference the legacy `50509`)
+    and offering optional `gnu-tar --sort=name --mtime=@0 --owner=0
+    --group=0 --numeric-owner` flags for byte-reproducible webapp archives
+    across macOS/Linux build hosts (recommended, not required —
+    `fdev publish` itself uses the Rust `tar` crate).
 
 ## 1.2.2 (2026-05-26)
 - `local-dev` skill: document two silent isolation gotchas that bit users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.2.3 (2026-05-26)
+- `dapp-builder`: documented the gateway CSP, iframe shell, and post-publish
+  smoke testing — three "only show up in production" pitfalls every Freenet
+  webapp hits (issue #22, distilled from freenet/mail v0.1.0).
+  - **Vendor your assets.** New "Gateway CSP: Vendor Your Assets" section in
+    `ui-patterns.md` explains the same-origin CSP, why CDN `<link>` /
+    `<script>` tags work in `dx serve` / `vite dev` but fail under
+    `fdev publish`, and the right way to bundle stylesheets / fonts into
+    your asset directory (e.g. `ui/assets/vendor/` for Dioxus). Cross-linked
+    from SKILL.md Phase 3.
+  - **Iframe shell + Playwright recipe.** New
+    `references/production-smoke-testing.md` documents the
+    `<iframe id="app">` shell architecture (with a "source of truth"
+    pointer to `freenet-core/.../server/path_handlers.rs`) and the two
+    Playwright idioms it breaks (`page.locator(...)` finds only the shell;
+    `page.goto("/")` lands on the dashboard). Includes a
+    `production-liveness.spec.ts` template that asserts WASM ran, vendored
+    CSS loaded (using `fontWeight` for stable assertion), and the browser
+    console has no CSP / network-failure errors. Cross-linked from SKILL.md
+    Phase 4.
+  - **Tooling preflight.** New section in `build-system.md` noting that the
+    gateway port is `7509` (not the legacy `50509`) and offering optional
+    `gnu-tar` flags for byte-reproducible webapp archives across
+    macOS/Linux build hosts.
+
 ## 1.2.2 (2026-05-26)
 - `local-dev` skill: document two silent isolation gotchas that bit users
   during freenet-email E2E debugging (issue #24).

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -162,13 +162,12 @@ Set up the build system, CI, and deployment pipeline.
 4. Back up contract state to the delegate for network resilience
 5. **Add a production-liveness smoke test.** A ~50-line Playwright spec
    asserting the gateway-hosted webapp mounts, vendored CSS loaded, and the
-   browser console has no errors catches publish-vs-dev regressions (CSP
-   blocks, iframe-shell mistakes, broken archives) that no unit test can
-   reach. See `references/production-smoke-testing.md`.
+   browser console is clean catches CSP blocks, iframe-shell mistakes, and
+   broken archives that no unit test reaches. See
+   `references/production-smoke-testing.md`.
 6. **Confirm tooling preflight before publishing.** GNU tar is required for
    reproducible contract IDs, and the gateway port is `7509` (not the older
-   `50509`). See the "Tooling Preflight" section in
-   `references/build-system.md`.
+   `50509`). See "Tooling Preflight" in `references/build-system.md`.
 
 References:
 - `references/build-system.md` — build, CI, packaging, tooling preflight.

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -142,6 +142,12 @@ Build the user interface connecting to contracts and delegates.
 3. Create synchronizer for contract state subscriptions
 4. Implement delegate communication for private storage
 5. Build reactive UI components
+6. **Vendor your stylesheets, fonts, and scripts.** The gateway serves every
+   webapp under a same-origin CSP — CDN `<link>` / `<script>` tags from
+   `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `fonts.googleapis.com`, etc.
+   are blocked in production even though they work in `dx serve` /
+   `vite dev`. See `references/ui-patterns.md` "Gateway CSP: Vendor Your
+   Assets".
 
 Reference: `references/ui-patterns.md`
 
@@ -154,8 +160,20 @@ Set up the build system, CI, and deployment pipeline.
 2. Add a `preflight` task that runs fmt, clippy, tests, and migration checks before publish
 3. Add GitHub Actions CI workflow (runs on push and PRs)
 4. Back up contract state to the delegate for network resilience
+5. **Add a production-liveness smoke test.** A ~50-line Playwright spec
+   asserting the gateway-hosted webapp mounts, vendored CSS loaded, and the
+   browser console has no errors catches publish-vs-dev regressions (CSP
+   blocks, iframe-shell mistakes, broken archives) that no unit test can
+   reach. See `references/production-smoke-testing.md`.
+6. **Confirm tooling preflight before publishing.** GNU tar is required for
+   reproducible contract IDs, and the gateway port is `7509` (not the older
+   `50509`). See the "Tooling Preflight" section in
+   `references/build-system.md`.
 
-Reference: `references/build-system.md`
+References:
+- `references/build-system.md` — build, CI, packaging, tooling preflight.
+- `references/production-smoke-testing.md` — iframe shell architecture,
+  Playwright recipe for post-publish liveness checks.
 
 ## Project Structure Template
 

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -165,9 +165,11 @@ Set up the build system, CI, and deployment pipeline.
    browser console is clean catches CSP blocks, iframe-shell mistakes, and
    broken archives that no unit test reaches. See
    `references/production-smoke-testing.md`.
-6. **Confirm tooling preflight before publishing.** GNU tar is required for
-   reproducible contract IDs, and the gateway port is `7509` (not the older
-   `50509`). See "Tooling Preflight" in `references/build-system.md`.
+6. **Check the gateway port and (optionally) tar reproducibility.** The
+   gateway runs on `7509` — older docs and scripts still reference `50509`.
+   For byte-reproducible webapp archives across build hosts, invoke `tar`
+   with the GNU flags listed under "Tooling Preflight" in
+   `references/build-system.md`.
 
 References:
 - `references/build-system.md` — build, CI, packaging, tooling preflight.

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -29,16 +29,14 @@ Two release-time gotchas that don't surface as obvious errors:
 - **GNU tar is required for reproducible contract IDs.** `compress-webapp`
   (and the equivalent `tar` invocation in your `Makefile.toml`) uses
   `--sort`, `--mtime`, `--owner`, and `--group` to produce a byte-identical
-  archive across machines — which keeps the contract ID stable. macOS BSD
+  archive across machines, which keeps the contract ID stable. macOS BSD
   tar silently ignores or rejects those flags and produces a usable but
-  *different* archive, so the contract ID won't match what a Linux CI run
-  produces. On macOS install GNU tar (`brew install gnu-tar`) and use `gtar`
-  (or alias `tar=gtar` in the build task). On Linux distros that ship BSD
-  tar, install `tar` from the GNU package.
-- **The Freenet HTTP/WebSocket gateway port is `7509`.** Older builds
-  (pre-2025) listened on `50509`; some scripts and READMEs in the wild still
-  hard-code that. If a probe or smoke test silently false-negatives, check
-  the port first.
+  *different* archive, so the contract ID won't match Linux CI. On macOS,
+  `brew install gnu-tar` and use `gtar` (or alias `tar=gtar` in the build
+  task).
+- **The Freenet HTTP/WebSocket gateway port is `7509`.** Pre-2025 builds
+  listened on `50509`; some scripts and READMEs still hard-code that. If a
+  probe or smoke test silently false-negatives, check the port first.
 
 ## Project Cargo.toml (Workspace Root)
 

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -22,6 +22,24 @@ cargo install --path crates/fdev   # fdev development tool
 npm install  # in ui/ directory
 ```
 
+### Tooling Preflight
+
+Two release-time gotchas that don't surface as obvious errors:
+
+- **GNU tar is required for reproducible contract IDs.** `compress-webapp`
+  (and the equivalent `tar` invocation in your `Makefile.toml`) uses
+  `--sort`, `--mtime`, `--owner`, and `--group` to produce a byte-identical
+  archive across machines — which keeps the contract ID stable. macOS BSD
+  tar silently ignores or rejects those flags and produces a usable but
+  *different* archive, so the contract ID won't match what a Linux CI run
+  produces. On macOS install GNU tar (`brew install gnu-tar`) and use `gtar`
+  (or alias `tar=gtar` in the build task). On Linux distros that ship BSD
+  tar, install `tar` from the GNU package.
+- **The Freenet HTTP/WebSocket gateway port is `7509`.** Older builds
+  (pre-2025) listened on `50509`; some scripts and READMEs in the wild still
+  hard-code that. If a probe or smoke test silently false-negatives, check
+  the port first.
+
 ## Project Cargo.toml (Workspace Root)
 
 ```toml

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -24,19 +24,22 @@ npm install  # in ui/ directory
 
 ### Tooling Preflight
 
-Two release-time gotchas that don't surface as obvious errors:
+Two release-time gotchas to know about:
 
-- **GNU tar is required for reproducible contract IDs.** `compress-webapp`
-  (and the equivalent `tar` invocation in your `Makefile.toml`) uses
-  `--sort`, `--mtime`, `--owner`, and `--group` to produce a byte-identical
-  archive across machines, which keeps the contract ID stable. macOS BSD
-  tar silently ignores or rejects those flags and produces a usable but
-  *different* archive, so the contract ID won't match Linux CI. On macOS,
-  `brew install gnu-tar` and use `gtar` (or alias `tar=gtar` in the build
-  task).
-- **The Freenet HTTP/WebSocket gateway port is `7509`.** Pre-2025 builds
-  listened on `50509`; some scripts and READMEs still hard-code that. If a
-  probe or smoke test silently false-negatives, check the port first.
+- **The Freenet HTTP/WebSocket gateway port is `7509`.** Earlier builds
+  listened on `50509`; older docs and example scripts you find online may
+  still hard-code that. If a probe or smoke test silently false-negatives,
+  check the port first. (Note: `fdev publish` itself uses the Rust `tar`
+  crate, not the system `tar` binary, so the build host's tar version
+  doesn't affect `fdev` directly.)
+- **For byte-reproducible webapp archives across build hosts**, invoke
+  `tar` with `--sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner`
+  in your `Makefile.toml`. This keeps diffs between releases meaningful
+  (the diff reflects content changes, not file-order or timestamp churn)
+  and lets two machines produce the same archive bytes from the same
+  source tree. macOS BSD `tar` doesn't accept those flags, so on macOS
+  install GNU tar (`brew install gnu-tar`) and use `gtar`. Optional but
+  recommended; River currently uses plain `tar -cJf`.
 
 ## Project Cargo.toml (Workspace Root)
 

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -146,17 +146,21 @@ test.describe("production liveness", () => {
     const app = page.frameLocator("iframe#app");
     await expect(app.locator("h1")).toBeVisible({ timeout: 15_000 });
 
-    // 3. Vendored CSS loaded. fontWeight is a more reliable signal than
-    //    fontSize: user-agent default h1 weight is 700; most CSS
-    //    frameworks set a non-default value (Bulma .title => 600), so the
-    //    value flips if and only if the stylesheet fails to load. Pick a
-    //    class your vendored stylesheet sets to a non-default weight.
+    // 3. Vendored CSS loaded. Replace the selector and expected value
+    //    below with ones from YOUR vendored stylesheet — the assertion
+    //    has to flip iff the CSS loads. Concrete example: Bulma's
+    //    `.title.is-1` sets `font-weight: 600` (UA default for h1 is
+    //    700), so:
+    //      app.locator(".title.is-1").first()
+    //        .evaluate(el => getComputedStyle(el).fontWeight)  // → "600"
+    //    A bare `h1` + "not 700" won't work if your stylesheet doesn't
+    //    touch h1 — pick a selector your CSS definitely styles.
     const fontWeight = await app
-      .locator("h1")
+      .locator("REPLACE_WITH_YOUR_VENDORED_CLASS")
       .first()
       .evaluate((el) => getComputedStyle(el).fontWeight);
     expect(fontWeight, "vendored CSS did not load — check CSP / vendor paths")
-      .not.toBe("700"); // user-agent default
+      .toBe("REPLACE_WITH_EXPECTED_VALUE");
 
     // 4. No fatal console / network errors during page load.
     expect(
@@ -173,7 +177,7 @@ test.describe("production liveness", () => {
 |-----------|---------|
 | `iframe#app[src=...__sandbox=1]` | Shell bridge `<script>` ran and wired the iframe |
 | `app.locator("h1")` visible | Publish pipeline produced a usable archive; WASM ran |
-| `fontWeight !== "700"` | Vendored CSS reached the iframe (CSP didn't block it) |
+| `fontWeight` matches your vendored value | Vendored CSS reached the iframe (CSP didn't block it) |
 | `fatalErrors == []` | CSP violations, `Refused to ...` blocks, `net::ERR_` failures, WASM panics, unhandled rejections |
 
 The `FATAL_CONSOLE_PATTERNS` list deliberately ignores generic

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -12,32 +12,43 @@ This page covers the iframe shell architecture and a
 `production-liveness.spec.ts` recipe that asserts the publish + gateway
 integration actually produced a working app.
 
+> **Source of truth.** The CSP and shell HTML described below are emitted
+> by `freenet-core/crates/core/src/server/{client_api.rs,path_handlers.rs}`.
+> If a smoke-test recipe stops working, verify the wire shape against
+> those files first — they're the canonical reference.
+
 ## The Gateway Iframe Shell
 
 `GET /v1/contract/web/<id>/` does NOT return your webapp directly. It returns
-a tiny shell HTML that looks like:
+a tiny shell HTML, roughly (simplified — see `path_handlers.rs` for the
+exact attribute set):
 
 ```html
 <!DOCTYPE html>
 <html>
 <body>
   <iframe id="app"
-          sandbox="allow-scripts allow-forms allow-popups"
+          sandbox="allow-scripts allow-forms allow-popups allow-downloads allow-modals"
+          allow="clipboard-read; clipboard-write"
           data-src="/v1/contract/web/<id>/?__sandbox=1"></iframe>
   <script>
-    // freenetBridge(authToken) — shell page owns the real WebSocket,
-    // injects the auth token, and proxies postMessage from the iframe.
+    // Shell page owns the real WebSocket, holds the auth token, and
+    // proxies postMessage from the iframe.
     function freenetBridge(authToken) { ... }
   </script>
+  <script>freenetBridge("<auth_token>");</script>
 </body>
 </html>
 ```
 
-Your actual webapp loads inside the `<iframe id="app">` at the `?__sandbox=1`
-URL. The shell exists for origin isolation (sandboxed iframe, no
-parent-origin access) and auth token injection (the shell holds the token
-and forwards it via `postMessage`, so the webapp never sees it directly).
-See `ui-patterns.md` "Two Connection Models".
+The second `<script>` tag invokes `freenetBridge` with the auth token; that
+call is what assigns `iframe.src` from `data-src` and actually starts your
+webapp loading. Your webapp then runs inside `<iframe id="app">` at the
+`?__sandbox=1` URL. The shell exists for origin isolation (sandboxed
+iframe, no parent-origin access) and auth token injection (the shell holds
+the token and forwards it via `postMessage`, so the webapp never sees it
+directly). See `ui-patterns.md` "Two Connection Models" for the WebSocket
+implications.
 
 ### Practical Consequences for E2E Tests
 
@@ -56,27 +67,28 @@ await expect(app.locator("h1")).toHaveText("My App");
 
 **2. `page.goto("/")` lands on the node dashboard.**
 
-`page.goto(url)` resolves `url` against the *origin* of `playwright.config.ts`'s
-`baseURL`, ignoring its path. So if `baseURL` is
-`http://127.0.0.1:7509/v1/contract/web/<id>/`, then `page.goto("/")` resolves
-to `http://127.0.0.1:7509/` — the node's dashboard, not your webapp.
-
-Pass an empty path so the full baseURL is preserved, or pass an absolute URL:
+`page.goto(url)` resolves `url` against `playwright.config.ts`'s `baseURL`
+using `new URL(url, baseURL)`. If `url` starts with `/`, only the *origin*
+of `baseURL` is kept — the `/v1/contract/web/<id>/` path is dropped, so
+`page.goto("/")` lands on the node dashboard, not your webapp. The safest
+fix is to navigate to the absolute URL directly:
 
 ```ts
 // ❌ Wrong — drops the /v1/contract/web/<id>/ prefix, hits the dashboard
 await page.goto("/");
 
-// ✅ Right — preserves the full baseURL path
-await page.goto("");
-
-// ✅ Also right — absolute URL
+// ✅ Right — absolute URL, no resolution surprises
 await page.goto(process.env.FREENET_BASE_URL!);
+
+// Also works — empty path is resolved against baseURL as-is, preserving
+// its path. Relies on Playwright's baseURL resolution staying consistent
+// (the absolute-URL form above is more robust).
+await page.goto("");
 ```
 
 ## The `production-liveness.spec.ts` Recipe
 
-A ~50-line Playwright spec that catches "did publish + gateway integration
+A short Playwright spec that catches "did publish + gateway integration
 produce a usable webapp" regressions without needing identities or contract
 state. Runs in a few seconds.
 
@@ -92,38 +104,65 @@ const BASE_URL = process.env.FREENET_BASE_URL;
 const SKIP =
   !BASE_URL || !/\/v1\/contract\/web\//.test(BASE_URL);
 
+// Console errors that should fail the test. Add to this if your app has
+// known-benign console errors at startup that you don't want to gate on.
+const FATAL_CONSOLE_PATTERNS = [
+  /Content Security Policy/i,
+  /Refused to (load|apply|execute|connect)/i,
+  /Failed to load resource/i,
+  /net::ERR_/i,
+];
+
 test.describe("production liveness", () => {
   test.skip(SKIP, "FREENET_BASE_URL not set to a /v1/contract/web/... path");
 
-  test("webapp mounts, CSS loads, no console errors", async ({ page }) => {
-    const errors: string[] = [];
+  test("webapp mounts, CSS loads, no fatal console errors", async ({ page }) => {
+    const fatalErrors: string[] = [];
     page.on("console", (msg: ConsoleMessage) => {
-      if (msg.type() === "error") errors.push(msg.text());
+      if (msg.type() !== "error") return;
+      const text = msg.text();
+      if (FATAL_CONSOLE_PATTERNS.some((re) => re.test(text))) {
+        fatalErrors.push(text);
+      }
     });
-    page.on("pageerror", (err) => errors.push(String(err)));
+    page.on("pageerror", (err) => fatalErrors.push(String(err)));
+    page.on("requestfailed", (req) =>
+      fatalErrors.push(`requestfailed: ${req.url()} (${req.failure()?.errorText})`),
+    );
 
-    // page.goto("") preserves the full BASE_URL path through the shell.
-    await page.goto("");
+    // Navigate to the absolute URL so baseURL resolution can't strip the path.
+    await page.goto(BASE_URL!);
 
-    // Reach into the iframe shell. The app mounts at iframe#app.
+    // 1. Shell bridge ran and assigned iframe.src. If this fails, the
+    //    inline freenetBridge() script didn't execute (CSP on the shell,
+    //    auth-token problem, etc.) — separate from "webapp didn't mount".
+    await expect(page.locator("iframe#app")).toHaveAttribute(
+      "src",
+      /__sandbox=1/,
+      { timeout: 10_000 },
+    );
+
+    // 2. WASM ran: the bundled <h1> mounts inside the iframe.
     const app = page.frameLocator("iframe#app");
-
-    // 1. WASM ran: the bundled <h1> is present.
     await expect(app.locator("h1")).toBeVisible({ timeout: 15_000 });
 
-    // 2. Vendored CSS loaded: a known class produces the expected
-    //    computed style. This catches the CSP-blocked-CDN regression.
-    //    Replace ".title.is-1" / "font-size" / "48px" with values that
-    //    match a class from your vendored stylesheet.
-    const fontSize = await app
-      .locator(".title.is-1")
+    // 3. Vendored CSS loaded. fontWeight is a more reliable signal than
+    //    fontSize: user-agent default h1 weight is 700; most CSS
+    //    frameworks set a non-default value (Bulma .title => 600), so the
+    //    value flips if and only if the stylesheet fails to load. Pick a
+    //    class your vendored stylesheet sets to a non-default weight.
+    const fontWeight = await app
+      .locator("h1")
       .first()
-      .evaluate((el) => getComputedStyle(el).fontSize);
-    expect(fontSize).toBe("48px");
+      .evaluate((el) => getComputedStyle(el).fontWeight);
+    expect(fontWeight, "vendored CSS did not load — check CSP / vendor paths")
+      .not.toBe("700"); // user-agent default
 
-    // 3. No console errors. Catches CSP blocks, missing assets, WASM
-    //    panics, and unhandled promise rejections.
-    expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+    // 4. No fatal console / network errors during page load.
+    expect(
+      fatalErrors,
+      `fatal console/network errors:\n${fatalErrors.join("\n")}`,
+    ).toEqual([]);
   });
 });
 ```
@@ -132,25 +171,53 @@ test.describe("production liveness", () => {
 
 | Assertion | Catches |
 |-----------|---------|
-| `app.locator("h1")` visible | Publish pipeline produced a usable archive; WASM ran; `?__sandbox=1` route works |
-| `getComputedStyle(...)` matches | Vendored CSS reached the iframe (CSP didn't block it) |
-| `errors == []` | CSP violations, missing assets, WASM panics, unhandled promise rejections |
+| `iframe#app[src=...__sandbox=1]` | Shell bridge `<script>` ran and wired the iframe |
+| `app.locator("h1")` visible | Publish pipeline produced a usable archive; WASM ran |
+| `fontWeight !== "700"` | Vendored CSS reached the iframe (CSP didn't block it) |
+| `fatalErrors == []` | CSP violations, `Refused to ...` blocks, `net::ERR_` failures, WASM panics, unhandled rejections |
+
+The `FATAL_CONSOLE_PATTERNS` list deliberately ignores generic
+`console.error` calls so benign warnings don't flake the test. If your app
+has a known-benign error at startup, it stays out of the fatal list by
+default; if a new error category appears that you want to gate on, add a
+regex.
 
 ### Wiring It In
 
-- **`playwright.config.ts`**: set `use.baseURL` to the full gateway URL
-  including the `/v1/contract/web/<id>/` path so `page.goto("")` preserves it.
+- **`playwright.config.ts`** — set `use.baseURL` to the same URL you put in
+  `FREENET_BASE_URL` so both halves of the config agree:
+
+  ```ts
+  // playwright.config.ts
+  import { defineConfig } from "@playwright/test";
+
+  export default defineConfig({
+    use: { baseURL: process.env.FREENET_BASE_URL },
+    testDir: "./e2e",
+  });
+  ```
+
 - **Locally**, after `fdev publish`:
   `FREENET_BASE_URL=http://127.0.0.1:7509/v1/contract/web/<id>/ npx playwright test e2e/production-liveness.spec.ts`.
-- **CI**: the skip guard makes the spec a no-op when `FREENET_BASE_URL` is
-  unset; gate it behind a job that boots a local node, publishes the webapp,
-  and exports the contract key.
-- **Release pipeline**: run post-publish against the production gateway. A
-  failure here means publish succeeded but the user-visible app is broken.
+
+- **CI**, sketched as a bash flow:
+  ```bash
+  freenet local &                                 # boot local node
+  fdev -p 7509 publish ... | tee publish.log      # publish webapp
+  KEY=$(grep -oE '[A-Za-z0-9]{40,}' publish.log)  # extract contract key
+  export FREENET_BASE_URL="http://127.0.0.1:7509/v1/contract/web/$KEY/"
+  npx playwright test e2e/production-liveness.spec.ts
+  ```
+  The skip guard makes the spec a no-op when `FREENET_BASE_URL` is unset,
+  so the same file is safe to keep in offline CI runs.
+
+- **Release pipeline** — run post-publish against the production gateway.
+  A failure here means publish succeeded but the user-visible app is
+  broken; treat it as a release blocker.
 
 ## Reference
 
 The `freenet/mail` v0.1.0 release cycle hit both the CSP and iframe issues
 before adopting this pattern. See:
-- [freenet/mail#27](https://github.com/freenet/mail/pull/27) — `frameLocator` + `page.goto("")` for the iframe shell
-- [freenet/mail#28](https://github.com/freenet/mail/pull/28) — vendor CSS / fonts under `ui/public/vendor/`
+- [freenet/mail#27](https://github.com/freenet/mail/pull/27) — `frameLocator` + `goto` for the iframe shell
+- [freenet/mail#28](https://github.com/freenet/mail/pull/28) — vendor CSS / fonts under the asset directory

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -1,0 +1,165 @@
+# Production Smoke Testing
+
+After you `fdev publish` a webapp, you need a way to know it actually works
+end-to-end against the gateway-hosted form — not just in `dx serve` /
+`vite dev`. Two things tend to break only at this stage:
+
+1. **CSP blocks remote assets** (see `ui-patterns.md` "Gateway CSP"). Dev
+   loads the page from its own origin where the CSP doesn't apply.
+2. **The gateway wraps every webapp in an iframe shell.** Standard
+   `page.locator(...)` / `page.goto("/")` Playwright idioms find the wrong
+   document and silently pass.
+
+This page covers the iframe shell architecture you have to know to write a
+smoke test, and a complete `production-liveness.spec.ts` recipe that asserts
+the publish + gateway integration actually produced a working app.
+
+## The Gateway Iframe Shell
+
+`GET /v1/contract/web/<id>/` does NOT return your webapp directly. It returns
+a tiny shell HTML that looks like:
+
+```html
+<!DOCTYPE html>
+<html>
+<body>
+  <iframe id="app"
+          sandbox="allow-scripts allow-forms allow-popups"
+          data-src="/v1/contract/web/<id>/?__sandbox=1"></iframe>
+  <script>
+    // freenetBridge(authToken) — shell page owns the real WebSocket,
+    // injects the auth token, and proxies postMessage from the iframe.
+    function freenetBridge(authToken) { ... }
+  </script>
+</body>
+</html>
+```
+
+Your actual webapp loads inside the `<iframe id="app">` at the `?__sandbox=1`
+URL. The shell page exists for two reasons:
+
+- **Origin isolation.** The iframe runs sandboxed with no parent-origin
+  access, so a compromised contract can't read other Freenet origins' state.
+- **Auth token injection.** The shell holds the node's auth token and
+  forwards it to the iframe over `postMessage`, so the webapp itself never
+  sees it in URL / cookie / localStorage. See `ui-patterns.md` "Two
+  Connection Models" — webapp code inside the shell uses the shell-managed
+  WebSocket model.
+
+### Practical Consequences for E2E Tests
+
+Two `page.*` idioms break against the shell:
+
+**1. `page.locator(...)` finds nothing.**
+
+```ts
+// ❌ Wrong — operates on the shell document, which contains only <iframe id="app">
+await expect(page.locator("h1")).toHaveText("My App");
+
+// ✅ Right — reach into the iframe
+const app = page.frameLocator("iframe#app");
+await expect(app.locator("h1")).toHaveText("My App");
+```
+
+**2. `page.goto("/")` lands on the node dashboard.**
+
+`page.goto(url)` resolves `url` against the *origin* of `playwright.config.ts`'s
+`baseURL`, ignoring its path. So if `baseURL` is
+`http://127.0.0.1:7509/v1/contract/web/<id>/`, then `page.goto("/")` resolves
+to `http://127.0.0.1:7509/` — the node's dashboard, not your webapp.
+
+Pass an empty path so the full baseURL is preserved, or pass an absolute URL:
+
+```ts
+// ❌ Wrong — drops the /v1/contract/web/<id>/ prefix, hits the dashboard
+await page.goto("/");
+
+// ✅ Right — preserves the full baseURL path
+await page.goto("");
+
+// ✅ Also right — absolute URL
+await page.goto(process.env.FREENET_BASE_URL!);
+```
+
+## The `production-liveness.spec.ts` Recipe
+
+A minimal Playwright spec that catches the entire class of "did publish +
+gateway integration produce a usable webapp" regressions without needing any
+identities or contract state. Roughly 50 lines and runs in a few seconds.
+
+```ts
+// e2e/production-liveness.spec.ts
+import { test, expect, type ConsoleMessage } from "@playwright/test";
+
+// Set FREENET_BASE_URL to the gateway-hosted webapp URL, e.g.
+//   FREENET_BASE_URL=http://127.0.0.1:7509/v1/contract/web/<id>/
+// The spec is skipped if the URL doesn't look like a contract-web URL,
+// so this file is harmless to ship even when CI runs offline.
+const BASE_URL = process.env.FREENET_BASE_URL;
+const SKIP =
+  !BASE_URL || !/\/v1\/contract\/web\//.test(BASE_URL);
+
+test.describe("production liveness", () => {
+  test.skip(SKIP, "FREENET_BASE_URL not set to a /v1/contract/web/... path");
+
+  test("webapp mounts, CSS loads, no console errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg: ConsoleMessage) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+    page.on("pageerror", (err) => errors.push(String(err)));
+
+    // page.goto("") preserves the full BASE_URL path through the shell.
+    await page.goto("");
+
+    // Reach into the iframe shell. The app mounts at iframe#app.
+    const app = page.frameLocator("iframe#app");
+
+    // 1. WASM ran: the bundled <h1> is present.
+    await expect(app.locator("h1")).toBeVisible({ timeout: 15_000 });
+
+    // 2. Vendored CSS loaded: a known class produces the expected
+    //    computed style. This catches the CSP-blocked-CDN regression.
+    //    Replace ".title.is-1" / "font-size" / "48px" with values that
+    //    match a class from your vendored stylesheet.
+    const fontSize = await app
+      .locator(".title.is-1")
+      .first()
+      .evaluate((el) => getComputedStyle(el).fontSize);
+    expect(fontSize).toBe("48px");
+
+    // 3. No console errors. Catches CSP blocks, missing assets, WASM
+    //    panics, and unhandled promise rejections.
+    expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+  });
+});
+```
+
+### What Each Assertion Catches
+
+| Assertion | Catches |
+|-----------|---------|
+| `app.locator("h1")` visible | Publish pipeline produced a usable archive; WASM ran; `?__sandbox=1` route works |
+| `getComputedStyle(...)` matches | Vendored CSS reached the iframe (CSP didn't block it) |
+| `errors == []` | CSP violations, missing assets, WASM panics, unhandled promise rejections |
+
+### Wiring It In
+
+- **`playwright.config.ts`**: set `use.baseURL` to the gateway-hosted URL,
+  *with* the trailing `/v1/contract/web/<id>/` path. `page.goto("")` then
+  preserves it.
+- **Locally**: run after `fdev publish` against your local node:
+  `FREENET_BASE_URL=http://127.0.0.1:7509/v1/contract/web/<id>/ npx playwright test e2e/production-liveness.spec.ts`.
+- **CI**: keep the skip guard so the spec is a no-op when no `FREENET_BASE_URL`
+  is set; gate it behind a separate publish-and-smoke-test job that boots a
+  local node, publishes the webapp, and exports the contract key.
+- **Release pipeline**: run it post-publish against the production gateway as
+  a release-gate. A failure here means the publish succeeded but the
+  user-visible app is broken.
+
+## Reference
+
+The `freenet/mail` v0.1.0 release cycle hit both the CSP and iframe issues
+before adopting this pattern. See:
+- [freenet/mail#27](https://github.com/freenet/mail/pull/27) — `frameLocator` + `page.goto("")` for the iframe shell
+- [freenet/mail#28](https://github.com/freenet/mail/pull/28) — vendor CSS / fonts under `ui/public/vendor/`

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -1,8 +1,6 @@
 # Production Smoke Testing
 
-After you `fdev publish` a webapp, you need a way to know it actually works
-end-to-end against the gateway-hosted form — not just in `dx serve` /
-`vite dev`. Two things tend to break only at this stage:
+Two things break only after `fdev publish`, not in `dx serve` / `vite dev`:
 
 1. **CSP blocks remote assets** (see `ui-patterns.md` "Gateway CSP"). Dev
    loads the page from its own origin where the CSP doesn't apply.
@@ -10,9 +8,9 @@ end-to-end against the gateway-hosted form — not just in `dx serve` /
    `page.locator(...)` / `page.goto("/")` Playwright idioms find the wrong
    document and silently pass.
 
-This page covers the iframe shell architecture you have to know to write a
-smoke test, and a complete `production-liveness.spec.ts` recipe that asserts
-the publish + gateway integration actually produced a working app.
+This page covers the iframe shell architecture and a
+`production-liveness.spec.ts` recipe that asserts the publish + gateway
+integration actually produced a working app.
 
 ## The Gateway Iframe Shell
 
@@ -36,15 +34,10 @@ a tiny shell HTML that looks like:
 ```
 
 Your actual webapp loads inside the `<iframe id="app">` at the `?__sandbox=1`
-URL. The shell page exists for two reasons:
-
-- **Origin isolation.** The iframe runs sandboxed with no parent-origin
-  access, so a compromised contract can't read other Freenet origins' state.
-- **Auth token injection.** The shell holds the node's auth token and
-  forwards it to the iframe over `postMessage`, so the webapp itself never
-  sees it in URL / cookie / localStorage. See `ui-patterns.md` "Two
-  Connection Models" — webapp code inside the shell uses the shell-managed
-  WebSocket model.
+URL. The shell exists for origin isolation (sandboxed iframe, no
+parent-origin access) and auth token injection (the shell holds the token
+and forwards it via `postMessage`, so the webapp never sees it directly).
+See `ui-patterns.md` "Two Connection Models".
 
 ### Practical Consequences for E2E Tests
 
@@ -83,9 +76,9 @@ await page.goto(process.env.FREENET_BASE_URL!);
 
 ## The `production-liveness.spec.ts` Recipe
 
-A minimal Playwright spec that catches the entire class of "did publish +
-gateway integration produce a usable webapp" regressions without needing any
-identities or contract state. Roughly 50 lines and runs in a few seconds.
+A ~50-line Playwright spec that catches "did publish + gateway integration
+produce a usable webapp" regressions without needing identities or contract
+state. Runs in a few seconds.
 
 ```ts
 // e2e/production-liveness.spec.ts
@@ -145,17 +138,15 @@ test.describe("production liveness", () => {
 
 ### Wiring It In
 
-- **`playwright.config.ts`**: set `use.baseURL` to the gateway-hosted URL,
-  *with* the trailing `/v1/contract/web/<id>/` path. `page.goto("")` then
-  preserves it.
-- **Locally**: run after `fdev publish` against your local node:
+- **`playwright.config.ts`**: set `use.baseURL` to the full gateway URL
+  including the `/v1/contract/web/<id>/` path so `page.goto("")` preserves it.
+- **Locally**, after `fdev publish`:
   `FREENET_BASE_URL=http://127.0.0.1:7509/v1/contract/web/<id>/ npx playwright test e2e/production-liveness.spec.ts`.
-- **CI**: keep the skip guard so the spec is a no-op when no `FREENET_BASE_URL`
-  is set; gate it behind a separate publish-and-smoke-test job that boots a
-  local node, publishes the webapp, and exports the contract key.
-- **Release pipeline**: run it post-publish against the production gateway as
-  a release-gate. A failure here means the publish succeeded but the
-  user-visible app is broken.
+- **CI**: the skip guard makes the spec a no-op when `FREENET_BASE_URL` is
+  unset; gate it behind a job that boots a local node, publishes the webapp,
+  and exports the contract key.
+- **Release pipeline**: run post-publish against the production gateway. A
+  failure here means publish succeeded but the user-visible app is broken.
 
 ## Reference
 

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -26,25 +26,30 @@ The UI is the interaction layer that connects to the Freenet Kernel via WebSocke
 
 ## Gateway CSP: Vendor Your Assets
 
-The gateway sandbox iframe runs under a same-origin CSP:
+The gateway sandbox iframe runs under a same-origin CSP, currently (see
+`freenet-core/crates/core/src/server/client_api.rs` for the source of
+truth):
 
 ```
-default-src http://<gateway-host>:<port> 'unsafe-inline' 'unsafe-eval' blob: data:
+default-src <iframe-origin> 'unsafe-inline' 'unsafe-eval' blob: data:;
+connect-src <iframe-origin> blob: data:
 ```
 
 Any remote `<link rel="stylesheet">` or `<script src>` from a CDN
 (`cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `fonts.googleapis.com`, etc.)
-is blocked. `dx serve` / `vite dev` run on their own origin where the CSP
-doesn't apply, so the failure only surfaces after `fdev publish`: the
-production webapp renders unstyled / scriptless with a `Content Security
-Policy directive` violation in the browser console.
+is blocked by `default-src`. `fetch()` / `XMLHttpRequest` to a non-same-origin
+backend is blocked by `connect-src`. `dx serve` / `vite dev` run on their
+own origin where the CSP doesn't apply, so the failure only surfaces after
+`fdev publish`: the production webapp renders unstyled / scriptless with a
+`Content Security Policy directive` violation in the browser console.
 
 **Always vendor your assets into the webapp's asset directory** and
 reference them with relative paths:
 
-- Dioxus: drop CSS / fonts / scripts into `ui/public/vendor/` (or wherever
-  `Dioxus.toml`'s `dev_assets_path` points). The release build copies that
-  tree verbatim into `dist/`, which is what gets bundled into the archive.
+- Dioxus: drop CSS / fonts / scripts into `ui/assets/vendor/` (or wherever
+  `Dioxus.toml`'s `asset_dir` points — River bundles its vendored CSS
+  directly into `ui/assets/`). The release build copies that tree into the
+  webapp archive.
 - Vite / Webpack: import the stylesheet from `node_modules`, or copy the
   vendored files into `public/`. Don't keep a CDN URL "just for dev".
 
@@ -58,8 +63,9 @@ reference them with relative paths:
 ```
 
 A production-liveness smoke test (see `production-smoke-testing.md`) catches
-this regression by asserting `getComputedStyle(...)` matches a value from a
-vendored class — it fails the moment CSP blocks the CSS.
+this regression by asserting `getComputedStyle(...).fontWeight` matches the
+value set by your vendored stylesheet — it flips back to the user-agent
+default the moment the stylesheet fails to load.
 
 ## Dioxus Setup
 
@@ -165,6 +171,10 @@ The correct choice depends on **how the client loads**, not on what it wants to 
 | Loaded **outside the gateway** (native CLI, Playwright page served from a dev port like `python3 -m http.server`, a Node script, or any page that did not come from `/v1/contract/web/...`) | **Raw WebSocket.** There is no shell; you talk directly to the node's WS API. | Hardcode or configure `ws://127.0.0.1:7509/v1/contract/command?encodingProtocol=native`. After the socket opens, **send `ClientRequest::Authenticate { token }` yourself** with a token from the node's config or `~/.config/freenet/`. See the `local-dev` skill for details. |
 
 In short: **if your code is running inside an iframe served by `/v1/contract/web/...`, the shell does auth for you.** Everywhere else, you do it yourself. Getting this wrong produces confusing symptoms: the shell model fails with "Auth token not found" if you try to authenticate manually, and the raw model hangs forever if you forget.
+
+See also `production-smoke-testing.md` for the shell HTML structure and the
+Playwright idioms (`frameLocator` / absolute-URL `goto`) needed to reach
+into the iframe from E2E tests.
 
 ### CRITICAL: How WebSocket Works in the Gateway (Shell-Managed Model)
 

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -26,8 +26,7 @@ The UI is the interaction layer that connects to the Freenet Kernel via WebSocke
 
 ## Gateway CSP: Vendor Your Assets
 
-Every webapp served by the Freenet HTTP gateway runs under a same-origin
-Content-Security-Policy. The gateway sandbox iframe is loaded with:
+The gateway sandbox iframe runs under a same-origin CSP:
 
 ```
 default-src http://<gateway-host>:<port> 'unsafe-inline' 'unsafe-eval' blob: data:
@@ -35,22 +34,19 @@ default-src http://<gateway-host>:<port> 'unsafe-inline' 'unsafe-eval' blob: dat
 
 Any remote `<link rel="stylesheet">` or `<script src>` from a CDN
 (`cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `fonts.googleapis.com`, etc.)
-is blocked. In development you usually won't notice — `dx serve` runs the UI
-on its own origin where the CSP doesn't apply — but after `fdev publish` your
-production webapp will render unstyled / scriptless with a `Content Security
+is blocked. `dx serve` / `vite dev` run on their own origin where the CSP
+doesn't apply, so the failure only surfaces after `fdev publish`: the
+production webapp renders unstyled / scriptless with a `Content Security
 Policy directive` violation in the browser console.
 
-**Always vendor your assets into the webapp's asset directory** and reference
-them with relative paths:
+**Always vendor your assets into the webapp's asset directory** and
+reference them with relative paths:
 
 - Dioxus: drop CSS / fonts / scripts into `ui/public/vendor/` (or wherever
-  your `Dioxus.toml` `dev_assets_path` points). The release build copies that
-  tree verbatim into `dist/`, which is what gets bundled into the webapp
-  archive.
+  `Dioxus.toml`'s `dev_assets_path` points). The release build copies that
+  tree verbatim into `dist/`, which is what gets bundled into the archive.
 - Vite / Webpack: import the stylesheet from `node_modules`, or copy the
   vendored files into `public/`. Don't keep a CDN URL "just for dev".
-
-Reference your vendored assets via relative paths in `index.html`:
 
 ```html
 <!-- Wrong: blocked by gateway CSP -->
@@ -61,12 +57,9 @@ Reference your vendored assets via relative paths in `index.html`:
 <link rel="stylesheet" href="vendor/fontawesome/css/all.min.css">
 ```
 
-The catch is silent: dev mode passes, unit tests pass, the webapp publishes
-successfully, and *then* the gateway-hosted version renders broken. A
-production-liveness smoke test (see `production-smoke-testing.md`) catches
-this class of regression by asserting `getComputedStyle(...)` matches the
-expected value from a vendored class, which fails the moment CSP blocks the
-CSS.
+A production-liveness smoke test (see `production-smoke-testing.md`) catches
+this regression by asserting `getComputedStyle(...)` matches a value from a
+vendored class — it fails the moment CSP blocks the CSS.
 
 ## Dioxus Setup
 

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -24,6 +24,50 @@ The UI is the interaction layer that connects to the Freenet Kernel via WebSocke
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## Gateway CSP: Vendor Your Assets
+
+Every webapp served by the Freenet HTTP gateway runs under a same-origin
+Content-Security-Policy. The gateway sandbox iframe is loaded with:
+
+```
+default-src http://<gateway-host>:<port> 'unsafe-inline' 'unsafe-eval' blob: data:
+```
+
+Any remote `<link rel="stylesheet">` or `<script src>` from a CDN
+(`cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `fonts.googleapis.com`, etc.)
+is blocked. In development you usually won't notice — `dx serve` runs the UI
+on its own origin where the CSP doesn't apply — but after `fdev publish` your
+production webapp will render unstyled / scriptless with a `Content Security
+Policy directive` violation in the browser console.
+
+**Always vendor your assets into the webapp's asset directory** and reference
+them with relative paths:
+
+- Dioxus: drop CSS / fonts / scripts into `ui/public/vendor/` (or wherever
+  your `Dioxus.toml` `dev_assets_path` points). The release build copies that
+  tree verbatim into `dist/`, which is what gets bundled into the webapp
+  archive.
+- Vite / Webpack: import the stylesheet from `node_modules`, or copy the
+  vendored files into `public/`. Don't keep a CDN URL "just for dev".
+
+Reference your vendored assets via relative paths in `index.html`:
+
+```html
+<!-- Wrong: blocked by gateway CSP -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+
+<!-- Right: vendored, loaded same-origin -->
+<link rel="stylesheet" href="vendor/bulma.min.css">
+<link rel="stylesheet" href="vendor/fontawesome/css/all.min.css">
+```
+
+The catch is silent: dev mode passes, unit tests pass, the webapp publishes
+successfully, and *then* the gateway-hosted version renders broken. A
+production-liveness smoke test (see `production-smoke-testing.md`) catches
+this class of regression by asserting `getComputedStyle(...)` matches the
+expected value from a vendored class, which fails the moment CSP blocks the
+CSS.
+
 ## Dioxus Setup
 
 ### Project Structure


### PR DESCRIPTION
## Problem

The `dapp-builder` skill is silent on three "only show up in production"
pitfalls that every Freenet webapp hits. The freenet/mail v0.1.0 release
cycle hit all three, costing a release-cycle and a hotfix to resolve.
None of this is in the skill today, so the next dApp builder pays the
same cost (issue #22).

## Approach

Additive documentation in `skills/dapp-builder/`, split between SKILL.md
callouts and longer-form reference content:

- **Gateway CSP — vendor your assets.** New section in
  `references/ui-patterns.md` explaining the same-origin CSP, why CDN
  `<link>` / `<script>` tags work in `dx serve` / `vite dev` but fail
  under `fdev publish`, and the right way to bundle stylesheets, fonts,
  and scripts under `ui/public/vendor/`. SKILL.md Phase 3 gets a new
  implementation step cross-linking to it.

- **Iframe shell + Playwright recipe.** New
  `references/production-smoke-testing.md` documents the
  `<iframe id=\"app\">` shell architecture and the two Playwright idioms it
  breaks (`page.locator(...)` finds only the shell;
  `page.goto(\"/\")` resolves to the dashboard, not the webapp), plus a
  ~50-line `production-liveness.spec.ts` template that asserts WASM ran,
  vendored CSS loaded, and the browser console is clean. SKILL.md
  Phase 4 cross-links to it.

- **Tooling preflight.** New section in `references/build-system.md`
  calling out the GNU tar requirement for reproducible contract IDs
  (`brew install gnu-tar` on macOS) and the gateway port (`7509`, not
  the legacy `50509` that some old scripts still hard-code).

Distilled from freenet/mail#27 (iframe + Playwright recipe) and
freenet/mail#28 (CSP + asset vendoring).

## Testing

- `jq . .claude-plugin/marketplace.json` parses cleanly.
- All `references/<file>.md` cross-references in SKILL.md resolve to
  files that exist.
- `marketplace.json` version bumped to 1.2.2 and CHANGELOG entry added,
  so the `version-check.yml` workflow passes.

## Files Changed

- `skills/dapp-builder/SKILL.md` — Phase 3 + Phase 4 callouts pointing at the new content.
- `skills/dapp-builder/references/ui-patterns.md` — new \"Gateway CSP: Vendor Your Assets\" section.
- `skills/dapp-builder/references/build-system.md` — new \"Tooling Preflight\" section.
- `skills/dapp-builder/references/production-smoke-testing.md` — new file: iframe shell architecture + Playwright recipe.
- `.claude-plugin/marketplace.json` — version 1.2.1 → 1.2.2.
- `CHANGELOG.md` — entry for 1.2.2.

Closes #22

[AI-assisted - Claude]