### PR TITLE
docs: sync Freenet dApp practices from freenet/mail (v1.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.2.3"
+    "version": "1.3.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.3.0 (2026-05-28)
+
+Sync Freenet-specific dApp practices proven out in freenet/mail through
+May 2026 (issues #198, #199, #200, #206, #213, #251). Generic engineering
+practices (CI runner sizing, version-drift guards, pre-commit hooks, QA
+matrices, upstream-bug quarantine) deliberately left out of this version
+— they belong in a separate non-Freenet skill set.
+
+- `local-dev`: documented the **isolated multi-node harness pattern** —
+  `--config-dir` per node (NOT `--data-dir`) is what isolates
+  `config.toml` and transport keypairs across two `freenet` instances on
+  one host. On CI runners with `XDG_CONFIG_HOME` set, a `HOME=…`
+  override is bypassed and only `--config-dir` works.
+- `dapp-builder/build-system.md`: documented **per-contract lockfile
+  isolation** (`[workspace.exclude]` + own `Cargo.lock` + `=x.y.z` pins
+  + `CARGO_TARGET_DIR=<crate>/target` on every `fdev build`). Without
+  this pattern, a workspace dep bump silently rotates contract WASM
+  bytes and IDs, orphaning every user's stored state. Also documents
+  the **contract-ID reproducibility caveat**: signed-payload version is
+  a unix timestamp at signing time → contract IDs are NOT reproducible
+  from source, the committed `contract-id.txt` / `facade-id.txt` are
+  authoritative.
+- `dapp-builder/references/contract-patterns.md`: documented the
+  **chained-migration recipe** — append-only `LEGACY_*_CODE_HASHES`
+  walked oldest→newest on UI startup when an identity's recorded WASM
+  hash drifts from current; `pending_migration_from` on the delegate
+  for cross-session retry; recipient WASM hash captured at contact
+  import so upgraded senders can deliver to non-upgraded recipients;
+  the `current_hash_not_in_legacy` test invariant.
+- `local-dev`: documented installing `fdev` / `freenet` from the
+  freenet-core release tag's prebuilt `.tar.gz` rather than
+  `cargo install` — same binary CI uses, ~5s vs 10–15 min, and pins
+  you to a known fdev API surface (matters for the `--as-state` flag
+  used by facade pointer flips).
+- `dapp-builder/build-system.md`: documented the **pre-commit hook for
+  signed-and-committed publishing** — block stray `.wasm` outside
+  `published-contract/`, require `contract-id.txt` co-staged alongside
+  any WASM change. Without it, build artifacts leak into commits and
+  snapshot drift goes unnoticed.
+- `dapp-builder/references/production-smoke-testing.md`: documented the
+  **four Freenet dApp test tiers** (offline / iso / liveness / rust),
+  what each catches and what each misses, so a project doesn't ship
+  thinking a liveness smoke covers real round-trip behavior.
+- `systematic-debugging`: documented **structured-field log assertions**
+  in E2E — modern freenet-core (0.2.6x) emits tracing fields like
+  `phase="update_complete"` and `phase="relay_started"`. Asserting on
+  legacy wire-level markers (`UPDATE_PROPAGATION`) gives silent false
+  positives. Also: quarantine upstream bugs with `skip-with-reason`,
+  do not remove the test.
+- **NEW** `dapp-builder/references/facade-pattern.md`: full **stable-URL
+  facade contract architecture** — facade WASM (never rebuilt per
+  release) + facade-types crate + `FacadePointer { version,
+  current_app_id, prev_app_ids }` state + `fdev execute update
+  --as-state` (default `UpdateData::Delta` is silently rejected) +
+  `postMessage`-to-parent loader (gateway's `X-Frame-Options: DENY`
+  blocks same-window redirects from inside the sandbox iframe) +
+  webapp-cache busting after pointer flips + CI byte-equality check
+  with non-linux/amd64 bootstrap flow.
+
 ## 1.2.3 (2026-05-26)
 - `dapp-builder`: documented the gateway CSP, iframe shell, and post-publish
   smoke testing — three "only show up in production" pitfalls every Freenet

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -101,7 +101,7 @@ Start by listing each *kind* of shared state your app needs — each kind become
 3. Implement `ContractInterface` trait for the contract
 4. Ensure all state updates satisfy the commutative monoid requirement
 5. **Every field in state must be covered by a cryptographic signature** -- contracts run on untrusted peers who can modify unsigned fields. Write a test for each signed field verifying that tampering causes verification failure. See contract-patterns.md for versioned signature patterns when adding fields later.
-6. **Plan contract upgrade from v1.** Contract keys change with every WASM hash change, so include an `OptionalUpgrade` pointer in state, keep serialization backwards-compatible, and maintain a `legacy_contracts.toml` migration registry. See contract-patterns.md "Contract WASM Upgrade & State Migration".
+6. **Plan contract upgrade from v1.** Contract keys change with every WASM hash change. Pick a migration model based on who can sign updates on behalf of state: a shared-owner model uses an `OptionalUpgrade` pointer + `legacy_contracts.toml`; a per-user (no shared owner) model uses an append-only `LEGACY_*_CODE_HASHES` slice in the UI with a `pending_migration_from` retry marker on the delegate. See `contract-patterns.md` → "Contract WASM Upgrade & State Migration" and "Alternative: chained migration without on-chain pointer".
 7. **Read `state-authorization-patterns.md` before designing the second iteration.** It captures cross-cutting patterns (per-item vs bundled signatures, replay protection via monotonic counter / tombstones / cross-context binding, signed-payload hygiene, `time::now()` gotchas, related-contracts limits, wire-format stability) that bite on every contract beyond the trivial.
 
 References:
@@ -171,10 +171,26 @@ Set up the build system, CI, and deployment pipeline.
    with the GNU flags listed under "Tooling Preflight" in
    `references/build-system.md`.
 
+7. **If you'll ship more than one release, plan for a facade contract
+   from day one.** Without it, every release rotates the gateway URL
+   users have bookmarked. The facade is a stable-URL indirection: a
+   never-rebuilt contract whose state holds a signed pointer to the
+   current web-container. See `references/facade-pattern.md`. Cheaper
+   to design in now than retrofit later — retrofitting means asking
+   every existing user to update their bookmark.
+8. **Plan contract-WASM stability before the first release.** A
+   `cargo update` in the workspace root must not silently rotate
+   contract IDs. See `references/build-system.md` →
+   "Per-contract lockfile isolation".
+
 References:
-- `references/build-system.md` — build, CI, packaging, tooling preflight.
+- `references/build-system.md` — build, CI, packaging, tooling
+  preflight, per-contract lockfile isolation, contract-ID
+  reproducibility caveat, pre-commit hook for stray `.wasm`.
 - `references/production-smoke-testing.md` — iframe shell architecture,
   Playwright recipe for post-publish liveness checks.
+- `references/facade-pattern.md` — stable-URL facade contract
+  architecture for projects that ship more than one release.
 
 ## Project Structure Template
 

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -22,6 +22,44 @@ cargo install --path crates/fdev   # fdev development tool
 npm install  # in ui/ directory
 ```
 
+### Installing `fdev` / `freenet`
+
+Two ways. Pick deliberately.
+
+**From the freenet-core release tag (recommended for CI and reproducible
+local setups).** Download the prebuilt `.tar.gz` for your target from
+the freenet-core GitHub releases, extract `fdev` / `freenet` into
+`~/.cargo/bin/`, mark executable. This is the same artifact CI uses and
+takes ~5s instead of 10–15 min, and — importantly — it pins you to a
+known fdev API surface. The facade pointer-flip flow (`fdev execute
+update --as-state`) requires a recent enough fdev; older builds silently
+wrap the file as `UpdateData::Delta` and the on-chain contract rejects
+it. The release tag is the most reliable way to know which flags exist.
+
+```bash
+VERSION="0.2.65"   # match the gateway you publish to
+TARGET="$(uname -m)-$(uname | tr '[:upper:]' '[:lower:]')"
+case "$TARGET" in
+  arm64-darwin)  TRIPLE="aarch64-apple-darwin" ;;
+  x86_64-darwin) TRIPLE="x86_64-apple-darwin" ;;
+  *-linux)       TRIPLE="$(uname -m)-unknown-linux-musl" ;;
+esac
+
+cd /tmp
+curl -sSL "https://github.com/freenet/freenet-core/releases/download/v${VERSION}/fdev-${TRIPLE}.tar.gz"     | tar xz
+curl -sSL "https://github.com/freenet/freenet-core/releases/download/v${VERSION}/freenet-${TRIPLE}.tar.gz" | tar xz
+install -m 0755 fdev freenet ~/.cargo/bin/
+fdev --version && freenet --version
+```
+
+**From source (`cargo install --path …`).** Right when you're developing
+on freenet-core itself or you need an unreleased fix. Slower; gives you
+whatever's on the current branch, which may or may not match the
+gateway you're publishing to. **Version drift between your CLI and the
+gateway breaks publishes silently** (wire format / protocol enums change
+across stdlib minor releases) — see "Version drift is a real hazard"
+below.
+
 ### Tooling Preflight
 
 Two release-time gotchas to know about:
@@ -40,6 +78,164 @@ Two release-time gotchas to know about:
   source tree. macOS BSD `tar` doesn't accept those flags, so on macOS
   install GNU tar (`brew install gnu-tar`) and use `gtar`. Optional but
   recommended; River currently uses plain `tar -cJf`.
+
+## Per-contract lockfile isolation
+
+**The problem.** A Freenet contract ID is `hash(wasm, parameters)`. The
+WASM bytes depend on every transitive dependency. If your contract
+shares the workspace `Cargo.lock` with the UI crate, a routine bump to
+`dioxus`, `chrono`, `serde`, etc. resolves a different patch version
+deep in the contract's dependency tree → WASM bytes shift → contract ID
+rotates → every user's stored state under the old ID is orphaned.
+
+This happens silently. There is no warning. The first sign is users
+saying "my inbox is empty after the update."
+
+**The fix.** Exclude every committable-state contract / delegate from
+the workspace, give it its own `Cargo.lock`, and pin every dependency
+that affects WASM output with `=x.y.z`.
+
+```toml
+# Cargo.toml (workspace root)
+[workspace]
+members = ["common", "ui", "tools/*"]
+exclude = [
+    "contracts/inbox",
+    "contracts/facade",
+    "contracts/facade-types",      # shared types used by facade contract
+    "delegates/token-record",
+]
+```
+
+```toml
+# contracts/inbox/Cargo.toml — NOT a workspace member
+[package]
+name        = "my-inbox-contract"
+version     = "0.1.0"
+edition     = "2021"
+publish     = false
+
+# One-line stanza so fdev's get_workspace_target_dir() walk doesn't
+# panic when run from inside this crate.
+[workspace]
+
+[dependencies]
+freenet-stdlib = { version = "=0.6.0", features = ["contract"] }
+ml-dsa         = "=0.0.4"
+chrono         = { version = "=0.4.40", default-features = false }
+serde          = { version = "=1.0.219", features = ["derive"] }
+ciborium       = "=0.2.2"
+```
+
+Commit `contracts/inbox/Cargo.lock`. `cargo update` at the workspace
+root cannot touch it. The contract WASM stays byte-stable until you
+edit a `=x.y.z` pin in this manifest yourself.
+
+**`CARGO_TARGET_DIR` per crate.** `fdev build` walks up to find
+`Cargo.toml`, then uses cargo's default `target/` (which is the
+workspace's). Two problems: (1) it shares a `target/` with workspace
+builds whose dependency tree is different, so cargo wastes work, and
+(2) on machines that have the workspace `Cargo.lock`-locked target dir
+already populated, fdev's resolver disagrees with cargo and panics.
+Pin the target dir to the crate-local one in every build task:
+
+```toml
+# Makefile.toml
+[tasks.build-inbox-contract]
+description = "Build the inbox contract WASM (lockfile-isolated)"
+script = '''
+CRATE_DIR="${CARGO_MAKE_WORKING_DIRECTORY}/contracts/inbox"
+cd "$CRATE_DIR"
+CARGO_TARGET_DIR="$CRATE_DIR/target" fdev build --features contract
+'''
+```
+
+**Deliberate rotation.** When you DO want to rotate the contract ID
+(e.g. a contract upgrade), it's now a one-line diff: bump a `=x.y.z`
+pin in the contract's manifest, rebuild, and pair the change with the
+migration recipe in `contract-patterns.md` (append the prior
+`CODE_HASH` to your `LEGACY_*_CODE_HASHES` list). The rotation is now
+explicit, reviewable, and recoverable.
+
+## Contract ID reproducibility caveat
+
+Contract IDs are **not reproducible from source** under the
+signed-and-committed publishing pattern.
+
+The web-container / facade signed-payload format includes a `version`
+field, and the standard signer (`web-container-tool`) writes
+`SystemTime::now().as_secs()` into that field at signing time. Two
+developers signing the same source tree at different moments produce
+different payload bytes → different IDs.
+
+Why timestamp and not commit hash? The on-chain `web-container`
+contract's `update_state` requires strictly monotonic `version` across
+updates. A commit-hash scheme is not monotonic (any hash can compare
+either way against any other). A previous attempt at commit-hash
+versioning broke the v0.1.1 release of freenet/mail when the on-chain
+update was rejected for non-monotonic version.
+
+**Practical consequences.**
+
+- `published-contract/contract-id.txt` (and `facade-id.txt`) are
+  **authoritative artifacts**, not derivable. Commit them.
+- CI cannot verify "the source still produces this ID" — only "the
+  source still produces these WASM **bytes**". Use byte-equality on
+  `published-contract/<contract>.wasm`, not on the ID.
+- A second developer cannot "redo" a release from a clean checkout and
+  get the same ID; they must pull the committed snapshot.
+- `rust-toolchain.toml` must be committed and mirrored in any CI
+  workflow that rebuilds the contract — rustc version affects WASM
+  bytes, and the byte-equality check will fail if CI's rustc differs
+  from the one that produced the committed snapshot.
+
+## Publishing hygiene: pre-commit hook
+
+The signed-and-committed model means `published-contract/` is the only
+place a `.wasm` should ever live in the tree. Any other staged `.wasm`
+is either (a) a forgotten build artifact, or (b) a snapshot drift the
+author didn't notice. Both lose users access to old state when they
+land.
+
+Enforce it locally with a repo-managed git hook:
+
+```bash
+# .githooks/pre-commit
+#!/bin/bash
+set -euo pipefail
+
+stray=$(git diff --cached --name-only --diff-filter=A \
+        | grep -E '\.wasm$' \
+        | grep -v '^published-contract/' || true)
+if [ -n "$stray" ]; then
+    echo "error: .wasm files staged outside published-contract/:" >&2
+    echo "$stray" >&2
+    echo "Either move them to published-contract/ (with a matching" >&2
+    echo "contract-id.txt update) or add them to .gitignore." >&2
+    exit 1
+fi
+
+# If published-contract/*.wasm changed, contract-id.txt must change too.
+wasm_changed=$(git diff --cached --name-only \
+               | grep -E '^published-contract/.*\.wasm$' || true)
+if [ -n "$wasm_changed" ]; then
+    id_staged=$(git diff --cached --name-only \
+                | grep -E '^published-contract/(contract|facade)-id\.txt$' || true)
+    if [ -z "$id_staged" ]; then
+        echo "error: published-contract/*.wasm changed but no *-id.txt is staged." >&2
+        echo "Run \`cargo make update-published-contract\` (or the equivalent" >&2
+        echo "snapshot task) and stage the resulting *.wasm, *.parameters," >&2
+        echo "and *-id.txt together." >&2
+        exit 1
+    fi
+fi
+```
+
+Activate per-clone:
+
+```bash
+git config core.hooksPath .githooks
+```
 
 ## Project Cargo.toml (Workspace Root)
 

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -492,6 +492,90 @@ contract WASM at build time must be rebuilt and republished together. A stale
 CLI with old WASM produces a different key and can't see the new contract's
 state. See River's `cargo make publish-all` for how to orchestrate this.
 
+### Alternative: chained migration without on-chain pointer (freenet/mail)
+
+Some apps can't (or don't want to) write an `OptionalUpgrade` pointer
+into the old contract's state. The mail app is the canonical case:
+inbox state is per-identity and the user is the only one who can sign
+an update to their inbox. There's no shared "owner" who could push an
+upgrade pointer on everyone's behalf.
+
+The pattern mail uses instead:
+
+1. **Embed the current contract's WASM hash** in the UI at build time
+   (`INBOX_CODE_HASH = include!("…hash.txt")`).
+2. **Record per-identity which contract hash that user's state lives
+   under**, on the *delegate* (not on-chain) — e.g. an
+   `AliasInfo { inbox_wasm_hash: Option<String>, … }` on the identity
+   delegate, persisted client-side.
+3. **Maintain an append-only `LEGACY_*_CODE_HASHES` slice**, ordered
+   oldest → newest, listing every prior `INBOX_CODE_HASH` the project
+   has shipped.
+4. **On UI startup**, compare the recorded hash against current. If
+   they match, no-op. If they differ, walk forward through the legacy
+   slice starting from the recorded hash, dispatching a GET per
+   candidate. The first `GetResponse` to resolve wins — decode the
+   state, re-sign with the identity key, PUT under the current
+   contract's key. Update the recorded hash on the delegate.
+5. **Suppress duplicate migrations** by keying a `MIGRATED_IDENTITIES`
+   set on the cryptographic identity (the ML-DSA verifying-key bytes),
+   not on the mutable alias.
+6. **Persist a retry marker.** Stamp `pending_migration_from = Some(old_hash)`
+   on the delegate BEFORE dispatching GETs; clear it only when the PUT
+   under the current key succeeds. If the session ends before any GET
+   resolves (offline, browser crash, gateway hiccup), the next session
+   sees the marker and re-attempts.
+7. **Backwards-compat the delegate state** so old UI versions can read
+   the new fields: every new field on `AliasInfo` is
+   `#[serde(default)]`.
+
+```rust
+// ui/src/inbox.rs (or wherever the contract is bundled)
+pub const INBOX_CODE_HASH: &str = include_str!("../../published-contract/inbox-hash.txt");
+
+/// Append-only list, oldest → newest. Add the prior INBOX_CODE_HASH here
+/// every time you deliberately rotate the inbox contract.
+pub const LEGACY_INBOX_CODE_HASHES: &[&str] = &[
+    "9F2c…oldest",
+    "Bk7L…middle",
+    // current INBOX_CODE_HASH is NEVER in this slice
+];
+
+#[cfg(test)]
+#[test]
+fn current_hash_not_in_legacy() {
+    assert!(
+        !LEGACY_INBOX_CODE_HASHES.contains(&INBOX_CODE_HASH),
+        "current INBOX_CODE_HASH must not appear in LEGACY_INBOX_CODE_HASHES"
+    );
+}
+```
+
+**Cross-user sends with mixed versions.** If users on different
+contract versions need to address each other (e.g. mail), the *sender*
+must derive the recipient's contract key using the recipient's
+advertised WASM hash, not the sender's. Capture it at contact-import
+time from the import-fetch `GetResponse`'s `key.code_hash()` (requires
+`return_contract_code: true` on the GET request), store it on the
+contact record (`StoredContactKeys.inbox_wasm_hash:
+Option<String>` with `#[serde(default)]` for backwards-compat),
+and pass it explicitly when building the recipient's key in the send
+path. Own-identity derivations (e.g. updating your own inbox) keep
+using the sender's embedded `INBOX_CODE_HASH` and are correct by
+construction.
+
+Compared to the `OptionalUpgrade`-pointer model above:
+
+| Aspect | OptionalUpgrade pointer (River) | Chained migration (mail) |
+|---|---|---|
+| Who triggers the migration | Any updated client; owner writes pointer | The state's signer, in their own UI |
+| Where the legacy list lives | Embedded in WASM (read via build.rs from `legacy_contracts.toml`) | A Rust `const &[&str]` slice in the UI |
+| Recovery if a hop fails mid-flight | Pointer is permanent on-chain | `pending_migration_from` marker on delegate |
+| Works for per-user state with no shared owner | No | Yes |
+| Works for shared-room / single-owner state | Yes | Awkward (no one to sign migration for the room) |
+
+Pick the model that matches your contract's authorization shape.
+
 ## River Contract Reference
 
 See [River's room-contract](https://github.com/freenet/river/tree/main/contracts/room-contract/src/lib.rs) for a complete implementation, and River's `AGENTS.md` under "Contract Upgrade" for the full upgrade runbook.

--- a/skills/dapp-builder/references/facade-pattern.md
+++ b/skills/dapp-builder/references/facade-pattern.md
@@ -1,0 +1,365 @@
+# Facade Contract Pattern — Stable URLs Across Releases
+
+## Why
+
+A Freenet web-container contract ID is `hash(wasm, parameters)`. Every
+release rebuilds the UI → produces new WASM → produces a new contract
+ID → produces a new gateway URL.
+
+This is fine for early development, but it's hostile to users: every
+bookmark, every shared link, every external integration breaks the
+moment you ship. There's no DNS-equivalent to forward them.
+
+The **facade pattern** gives you a contract ID that stays byte-stable
+across every release. Users bookmark the facade URL once; per-release
+updates flip a pointer inside the facade's state to whatever the
+current web-container ID is. The facade WASM itself is never rebuilt.
+
+This is the pattern freenet/mail uses (issue #200). It is the
+recommended approach for any Freenet dApp that expects to ship more
+than one release.
+
+## Architecture
+
+Three pieces:
+
+```
+contracts/facade-types/         # tiny shared crate, types only
+contracts/facade/               # the on-chain facade contract (stable WASM)
+contracts/facade-loader/        # static HTML+JS shell the facade serves
+published-contract/
+├── facade.wasm                 # committed snapshot — never rebuilt per release
+├── facade.parameters           # 32 bytes: ed25519 verifying key
+├── facade-id.txt               # the stable contract ID users bookmark
+├── webapp.wasm                 # web-container WASM — rebuilt every release
+├── webapp.parameters
+└── contract-id.txt             # web-container ID — rotates every release
+```
+
+### `contracts/facade-types/`
+
+A tiny crate shared between the facade contract and the host-side
+signer. Dependencies: `ed25519-dalek`, `serde`. Nothing else. The
+smaller this crate's dependency closure, the less likely a workspace
+bump can rotate the facade WASM bytes (see `build-system.md` →
+"Per-contract lockfile isolation").
+
+```rust
+// contracts/facade-types/src/lib.rs
+pub const FACADE_MAX_PREV_APP_IDS: usize = 8;
+
+#[derive(Serialize, Deserialize)]
+pub struct FacadePointer {
+    pub version: u64,                       // unix timestamp at signing time
+    pub current_app_id: ContractInstanceId, // the web-container to serve now
+    pub prev_app_ids: Vec<ContractInstanceId>, // ring buffer for rollback
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FacadeMetadata {
+    pub pointer: FacadePointer,
+    pub signature: [u8; 64],   // ed25519 over signed_payload(pointer)
+}
+
+/// Canonical byte serialization used as the signature payload. Hand-rolled
+/// rather than CBOR/bincode to sidestep map-ordering / encoding concerns.
+pub fn signed_payload(p: &FacadePointer) -> Vec<u8> { /* ... */ }
+```
+
+### `contracts/facade/`
+
+The on-chain contract. Stable WASM. Its `update_state` accepts a new
+signed `FacadeMetadata`, verifies the signature with the embedded
+verifying key, checks `new.version > current.version` (strictly
+monotonic — same constraint as the web-container), and updates the
+`current_app_id`. The previous `current_app_id` is pushed onto
+`prev_app_ids` (ring buffer of size `FACADE_MAX_PREV_APP_IDS`).
+
+State framing matches the web-container's `[meta_len][meta][web_len][web]`
+layout — `meta` carries the `FacadeMetadata`, `web` carries the loader
+tar.xz.
+
+### `contracts/facade-loader/`
+
+A static HTML+JS shell that the facade serves as its `web` slot.
+Per-release the loader is re-rendered with the new web-container ID
+baked in, tarred, xz-compressed, and packed into the new facade state.
+
+```html
+<!-- contracts/facade-loader/src/index.html.tmpl -->
+<!doctype html>
+<html><head><meta charset="utf-8"><title>Loading…</title></head>
+<body>
+<script>
+const CURRENT_APP_ID = "{{CURRENT_APP_ID}}";  // substituted by build-loader.sh
+const target = `/v1/contract/web/${CURRENT_APP_ID}/`;
+
+if (window.parent !== window && !location.search.includes("__sandbox=1")) {
+    // Running inside the gateway's shell iframe.
+    window.parent.postMessage(
+        { __freenet_shell__: true, type: "navigate", href: target },
+        "*"
+    );
+} else {
+    // Standalone (dev / ?__sandbox=1 / no parent). Direct redirect.
+    window.location.replace(target);
+}
+</script>
+<noscript>Open <a href="${target}">${target}</a> manually.</noscript>
+</body></html>
+```
+
+## Per-release flow
+
+`scripts/release.sh` chains these automatically. Manually:
+
+```bash
+# 1. Build the new web-container webapp (rotates contract-id.txt).
+cargo make build
+NEW_APP_ID=$(cat published-contract/contract-id.txt)
+FACADE_ID=$(cat published-contract/facade-id.txt)
+
+# 2. Re-render the loader with the new ID baked in.
+scripts/build-loader.sh "$NEW_APP_ID"
+# → contracts/facade-loader/dist/index.html
+
+# 3. Pack the loader into the format the gateway expects.
+cargo make pack-facade-loader
+# → target/facade/loader.tar.xz
+
+# 4. Sign a fresh FacadePointer with the production key.
+cargo make sign-facade-state
+# → target/facade/facade.state  (FacadeMetadata { pointer, signature } framed)
+
+# 5. Push the new state to the facade contract.
+#    --as-state is REQUIRED (see "fdev gotcha" below).
+fdev execute update --as-state "$FACADE_ID" target/facade/facade.state
+```
+
+After step 5 the facade URL at
+`http://127.0.0.1:7509/v1/contract/web/$FACADE_ID/` redirects to the new
+webapp. The facade contract ID is unchanged.
+
+## fdev gotcha: `--as-state` is required
+
+```bash
+# WRONG — fdev wraps the file as UpdateData::Delta, the facade contract's
+# update_state matches Delta(_) => Err(InvalidUpdate), and the gateway
+# returns success silently. The pointer is never flipped.
+fdev execute update "$FACADE_ID" target/facade/facade.state
+
+# RIGHT — wraps as UpdateData::State, which is what update_state matches.
+fdev execute update --as-state "$FACADE_ID" target/facade/facade.state
+```
+
+Preflight your release script so it fails loud if the local `fdev` is too
+old:
+
+```bash
+if ! fdev execute update --help 2>&1 | grep -q -- '--as-state'; then
+    echo "error: fdev does not support --as-state — install a release built" >&2
+    echo "from a freenet-core that has it. See build-system.md → installing fdev." >&2
+    exit 1
+fi
+```
+
+## Loader: postMessage, NOT location.replace
+
+The gateway wraps every contract URL in a shell page with
+`X-Frame-Options: DENY`, serving the contract's web slot inside a
+sandboxed iframe. The shell page is what holds the navigation address bar
+(metaphorically) and listens for `__freenet_shell__` messages from
+contract code.
+
+If the loader does `location.replace(target)` from inside the sandbox,
+the browser tries to load the *new contract's shell page* INSIDE our
+iframe. The new shell page also has `X-Frame-Options: DENY` — so the
+browser blocks it. You see a blank page and a console error about
+frame-ancestors.
+
+The right way is to `postMessage({type:"navigate", href}, "*")` to
+`window.parent` and let the gateway's shell handle the cross-contract
+navigation in the top window.
+
+Keep a fallback path for development / `?__sandbox=1`: if `window.parent
+=== window` or the sandbox flag is set, use `location.replace` directly.
+That's how you smoke-test the loader without a gateway.
+
+## Gateway cache busting after a pointer flip
+
+The gateway extracts a contract's tar.xz on `GetResponse`, caches the
+extracted files to disk, and serves subsequent requests from cache.
+**UPDATEs that change the `web` slot do not invalidate the cache** until
+the next GET hits a cache miss. Right after a pointer flip, browsers
+hitting `…/web/$FACADE_ID/` see the old loader (pointing at the previous
+app) until the cache TTL expires.
+
+Bust it manually after every flip until upstream fixes this:
+
+```bash
+# macOS
+CACHE="$HOME/Library/Caches/The-Freenet-Project-Inc.freenet/webapp_cache"
+# Linux
+CACHE="$HOME/.cache/freenet/webapp_cache"
+
+rm -rf "$CACHE/$FACADE_ID" "$CACHE/$FACADE_ID.hash"
+
+# Trigger a fresh GetResponse to repopulate.
+curl -s -o /dev/null "http://127.0.0.1:7509/v1/contract/web/$FACADE_ID/"
+```
+
+(Track this as a freenet-core gateway issue the next time you hit it.)
+
+## What to commit, what to ignore
+
+Commit:
+
+- `published-contract/facade.wasm` — the canonical, byte-stable artifact.
+- `published-contract/facade.parameters` — the 32-byte verifying key.
+- `published-contract/facade-id.txt` — the contract ID derived from the
+  two above.
+
+Do NOT commit:
+
+- `target/facade/facade.state` — signed with the production key, includes
+  a per-build timestamp version. Re-signed every release. Committing it
+  bloats history and leaks signing-machine timestamps.
+- `contracts/facade-loader/dist/index.html` — regenerated from
+  `index.html.tmpl` at every release. Edit the `.tmpl`, let
+  `build-loader.sh` re-render.
+
+## CI byte-equality enforcement
+
+The whole point of the facade is that its WASM is byte-stable. CI must
+enforce that. In `.github/workflows/check-contract-wasm.yml`:
+
+```yaml
+- name: Rebuild facade WASM and compare against committed snapshot
+  run: |
+    scripts/build-facade-snapshot-linux.sh
+    cmp published-contract/facade.wasm target/facade-build/facade.wasm \
+      || { echo "::error::facade.wasm drift — see facade-pattern.md"; exit 1; }
+```
+
+Failure here is a release blocker. Possible causes:
+
+1. **Someone bumped a dependency in `contracts/facade/Cargo.toml` or
+   `contracts/facade-types/Cargo.toml`.** If deliberate (e.g. a security
+   fix in `ed25519-dalek`), regenerate the snapshot using the recipe
+   below and update `facade-id.txt` in the same PR. Announce loudly — the
+   stable URL is rotating, every bookmark breaks.
+2. **`rust-toolchain.toml` pin changed.** Same as above.
+3. **A workspace dep leaked in** because the facade isn't actually in
+   `[workspace.exclude]` or doesn't have its own `Cargo.lock`. See
+   `build-system.md` → "Per-contract lockfile isolation".
+
+### Regenerating the facade snapshot from a non-Linux host
+
+CI builds on linux/amd64. If your dev box is macOS/arm64, qemu
+emulation can produce subtly different WASM bytes from CI's native
+build. Don't fight it. Use a CI-bootstrap flow:
+
+```bash
+# 1. Push the change with a placeholder facade.wasm (any non-empty file).
+#    The byte-equality check WILL fail; that's fine.
+
+# 2. CI's job uploads the freshly built facade.wasm as an artifact
+#    (e.g. named "facade-wasm-rebuilt-<sha>").
+RUN_ID=$(gh run list --workflow check-contract-wasm.yml --limit 1 --json databaseId -q '.[0].databaseId')
+gh run download "$RUN_ID" -n "facade-wasm-rebuilt-${SHA}" -D /tmp/facade-rebuilt
+
+# 3. Replace the committed snapshot with CI's output.
+cp /tmp/facade-rebuilt/facade.wasm published-contract/facade.wasm
+
+# 4. Recompute the contract ID.
+fdev get-contract-id \
+    --code published-contract/facade.wasm \
+    --parameters published-contract/facade.parameters \
+    > published-contract/facade-id.txt
+
+# 5. Commit, push. CI now passes.
+git add published-contract/facade.{wasm,id.txt}
+git commit -m "chore(facade): regenerate snapshot from CI build"
+```
+
+Local `check-facade-byte-equal.sh` should skip with a warning on
+non-canonical hosts so devs aren't blocked by emulation drift.
+
+## Production key lifecycle
+
+The facade's verifying key is embedded in its `parameters` blob —
+**rotating the key rotates the facade contract ID.** The whole point of
+the facade is to never do that. So the signing key needs the same care
+as a long-lived CA root.
+
+```bash
+# One-time, on a trusted machine.
+scripts/generate-production-key.sh
+# → ~/.config/freenet-email/web-container-keys.toml (chmod 600)
+```
+
+Rules:
+
+- **Never commit** the signing key. Add the config path to `.gitignore`
+  and add a pre-commit check that refuses to stage it.
+- **Back it up offline immediately.** Password manager + encrypted USB
+  + printed QR in a physical safe. Pick three of those, not just one.
+  Losing the key means generating a new one, regenerating the facade
+  snapshot, publishing a new facade contract with a new ID, and
+  notifying every user that their bookmark is dead.
+- Override path with `WEB_CONTAINER_KEY_FILE=/path/to/keys.toml` if you
+  use a hardware token / agent that exposes the key under a different
+  path.
+- The same key signs both the web-container `webapp.metadata` and the
+  facade's `FacadeMetadata`. They're two contracts with the same
+  publisher identity. Don't generate separate keys; you'll just have two
+  things to back up and your operational risk doubles.
+
+## Recovery: manual pointer flip after script failure
+
+`scripts/release.sh` is idempotent up to step 7 (commit) — if it dies
+between publishing the new webapp and flipping the facade pointer
+(e.g. fdev's default 300s timeout fires even though the gateway accepted
+the request), recover manually:
+
+```bash
+NEW_APP_ID=$(cat published-contract/contract-id.txt)
+FACADE_ID=$(cat published-contract/facade-id.txt)
+
+# 1. Confirm the new webapp actually landed.
+curl -sI "http://127.0.0.1:7509/v1/contract/web/$NEW_APP_ID/" | head -1
+# Expect: HTTP/1.1 200 OK
+
+# 2. Re-render loader + re-sign pointer.
+cargo make sign-facade-state
+
+# 3. Push the pointer update.
+fdev execute update --as-state "$FACADE_ID" target/facade/facade.state
+# Expect: "Contract updated successfully"
+
+# 4. Bust the gateway cache (see above).
+
+# 5. Verify the pointer in the loader.
+curl -s "http://127.0.0.1:7509/v1/contract/web/$FACADE_ID/?__sandbox=1" \
+    | grep "$NEW_APP_ID"
+# Expect: the new app ID appears in the rendered loader.
+
+# 6. Browser smoke: open the facade URL, watch DevTools network tab,
+#    confirm postMessage navigation lands on the new web-container.
+```
+
+If step 1 returns anything other than 200, the publish itself failed
+mid-flight; do not flip the pointer. Re-run from `cargo make
+publish-production` — the publish step is idempotent (PUTting an already
+published contract is a no-op).
+
+## Cross-references
+
+- Lockfile isolation that keeps facade WASM byte-stable: `build-system.md`
+  → "Per-contract lockfile isolation".
+- Why the contract ID is not reproducible from source: `build-system.md`
+  → "Contract ID reproducibility caveat".
+- The two-message gateway shell architecture and CSP gotchas:
+  `ui-patterns.md` → "Two Connection Models".
+- Smoke-testing the facade URL after release:
+  `production-smoke-testing.md`.

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -1,6 +1,34 @@
 # Production Smoke Testing
 
-Two things break only after `fdev publish`, not in `dx serve` / `vite dev`:
+## The four test tiers of a Freenet dApp
+
+Don't conflate them. Each catches a different failure mode; none of them
+catches what the others catch.
+
+| Tier | What it runs | What it catches | What it misses |
+|---|---|---|---|
+| **rust** | `cargo test --workspace` (incl. `cargo test -p <contract> --features contract` for host-side contract tests) | State logic, commutative-monoid invariants, serialization round-trips, signature verification, validation rules. | Anything involving a live node or the gateway. |
+| **offline** | UI build with `--features example-data,no-sync --no-default-features`, served via `dx serve`, driven by Playwright. | UI flows that don't depend on a node: identity creation against mock data, render correctness, navigation, form validation. | Real WebSocket bridge, real contract PUT/GET/UPDATE, real delegate calls, real AFT, gateway behavior. |
+| **iso** (isolated multi-node E2E) | `cargo make test-e2e-real-node` style: spin up a 2-node Freenet network on `127.0.0.1` via the iso-nodes harness (see `local-dev` SKILL → "isolated multi-node"), publish the webapp, drive the UI via Playwright. | Real round-trip behavior: identity creation persisted to the delegate, contract PUTs landing, AFT burns, cross-node propagation, decrypt-on-receive. Catches the bugs that only appear with a real node. | Production gateway specifics (production has different deployments, NAT, real peer counts). Cost: 5–10 min per run; gate to tags / nightly. |
+| **liveness** | `production-liveness.spec.ts` against the **deployed gateway URL** post-release. | Publish-pipeline bugs: corrupted tar.xz, wrong signature, stale `contract-id.txt`, routing misconfig, gateway CSP regression, iframe-shell regression, vendored asset 404s. **Intentionally minimal** — gateway serves webapp, WASM loads, Dioxus mounts, "create new identity" link renders. | Real round-trip. The deployed gateway has no test fixtures and the test runs as a real user with no identity — it can't verify message delivery, AFT, contract migration, or anything past first render. |
+
+**The shape of a healthy release:**
+
+1. `rust` + `offline` gate every PR.
+2. `iso` gates release tags (or runs nightly if you have <1 release/week).
+3. `liveness` runs immediately post-publish and tells you whether
+   anything reached the live gateway at all.
+4. To verify real round-trip in production after a release, either run
+   `iso` against a fresh `freenet local` node pointed at the published
+   contract ID, or follow a manual 7-step checklist (compose → send →
+   switch identity → verify delivery → AFT burn check → reload-persist
+   → cross-identity send via address book). There is no shortcut here;
+   `liveness` does not cover it.
+
+## The two production-only pitfalls
+
+Two things break only after `fdev publish`, not in `dx serve` /
+`vite dev`:
 
 1. **CSP blocks remote assets** (see `ui-patterns.md` "Gateway CSP"). Dev
    loads the page from its own origin where the CSP doesn't apply.

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -179,6 +179,34 @@ on a fresh publish to the test node, because the system node has stale
 contract state from a previous run signed by a different key. If you see
 this on a "fresh" test, check which node `fdev` actually hit.
 
+#### `--data-dir` does NOT isolate `config.toml` either — use `--config-dir` per node
+
+Two `freenet` processes on the same host that pass the same (or default)
+config directory share `config.toml` AND `secrets/transport-keypair.pem`.
+Symptoms: second node fails to bind its UDP port, or both nodes use
+identical peer IDs and the network refuses the duplicate connection.
+
+For a deterministic multi-node harness on one host (gateway + peer + …),
+pass `--config-dir` explicitly to each node, NOT just `--data-dir`:
+
+```bash
+freenet network --config-dir /tmp/iso-net/gw/config   --data-dir /tmp/iso-net/gw/data   ...
+freenet network --config-dir /tmp/iso-net/peer/config --data-dir /tmp/iso-net/peer/data ...
+```
+
+**CI gotcha:** on Linux runners that set `XDG_CONFIG_HOME` (e.g. ubicloud,
+sometimes GitHub Actions images), `dirs::config_dir()` returns
+`$XDG_CONFIG_HOME` regardless of `HOME` — so the `HOME=~/iso-home …`
+trick from the previous section is bypassed. `--config-dir` is the only
+flag that wins against `XDG_CONFIG_HOME`. Use it any time the harness
+must run identically on dev laptops and CI.
+
+A working reference harness lives at
+`scripts/run-isolated-nodes.sh` in the freenet/mail repo — covers up /
+down / wipe / status, full state wipe between test runs (avoids day-1
+AFT cap carryover in repeated E2E runs), and `FREENET_E2E_KEEP=1` to
+leave nodes up for post-mortem.
+
 ### Two-node local network
 
 ```bash

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -152,6 +152,41 @@ See [Module-Specific Debugging Guide](references/module-debugging.md) for detail
 
 **Note on telemetry:** If a `telemetry-monitor` skill is available in the project, use it to query network telemetry for constraining the problem (see Phase 1b). But remember: telemetry constrains, simulation reproduces. Don't spend cycles iterating on telemetry queries when you have enough information to write a simulation test.
 
+**Asserting on freenet-core logs from E2E tests: use structured fields,
+not wire-level markers.** Modern freenet-core (0.2.6x and later) emits
+tracing output as structured fields — `phase="update_complete"`,
+`phase="relay_started"`, `op="GET"`, `tx="01KK70…"`. Legacy
+wire-level grep markers (`UPDATE_PROPAGATION`, `OP_FORWARDED`, etc.)
+that older tests and tutorials reference have been removed. An E2E test
+that greps for them will pass forever — the line will never appear, so
+the negative assertion is vacuously true, and the test gives a false
+green.
+
+When writing or fixing an E2E log assertion against a freenet node:
+
+- Tail the log directly with the same `RUST_LOG` you'll use in CI and
+  read what's actually emitted around the event you care about. Don't
+  copy a grep pattern from an old test.
+- Match on the structured field shape — `phase="<value>"` is the most
+  stable; transaction IDs (`tx=`) are good for following a single
+  op across nodes.
+- Treat log assertions as supplementary. The authoritative check that
+  the system reached a state is the UI assertion (Playwright sees the
+  message in the recipient's inbox) or a contract GET via fdev (state
+  on the network matches expectations). Logs tell you *how* you got
+  there, not *whether* you got there.
+
+When a test fails because of a conclusively-traced upstream bug
+(e.g. a freenet-core relay timeout that has an open issue and a
+recognizable signature in the logs), **quarantine the path, do not
+remove the test.** Detect the exact upstream signature, emit a Playwright
+`test.skip()` (or equivalent) with the issue link, and let the assertion
+that would have caught the upstream bug stay in place. Genuine app-side
+regressions (contract errors, deserialization, panics, wrong state
+contents) still fail the gate. Removing the test, or weakening the
+assertion to make it always pass, loses the regression coverage you'd
+otherwise get for free the day upstream is fixed.
+
 For module-specific data gathering techniques, see [Module-Specific Debugging Guide](references/module-debugging.md) — it covers observation APIs, `#[freenet_test]` event capture, `RUST_LOG` targets, and fault injection per module.
 
 **Parallel investigation with subagents:**


### PR DESCRIPTION
## Summary

Capture production-tested Freenet dApp patterns proven out in
[freenet/mail](https://github.com/freenet/freenet-email) through May
2026 that were missing from the generic skills. Scoped to
**Freenet-specific** recipes only — generic engineering practices (CI
runner sizing, version-drift guards, QA matrices, pre-commit
hygiene-for-its-own-sake, upstream-bug quarantine pattern) deliberately
left out, to live in a future non-Freenet skill set.

Sources: freenet/mail issues #198 (lockfile isolation), #199 (chained
migration), #200 (facade contract), #206 (byte-equality CI), #213 / #251
(per-identity inbox + AFT migration), and the iso-nodes E2E harness
work.

## Changes

### New
- `skills/dapp-builder/references/facade-pattern.md` — full
  **stable-URL facade contract architecture**: `FacadePointer` state,
  `fdev execute update --as-state` requirement (default
  `UpdateData::Delta` silently rejected), `postMessage`-to-parent
  loader (gateway `X-Frame-Options: DENY` blocks same-window
  redirects inside the sandbox iframe), gateway webapp-cache busting
  after pointer flips, CI byte-equality with non-linux/amd64
  bootstrap flow, production-key lifecycle, manual pointer-flip
  recovery.

### Updated
- `skills/dapp-builder/references/build-system.md`
  - **Per-contract lockfile isolation** — `[workspace.exclude]` + own
    `Cargo.lock` + `=x.y.z` pins + `CARGO_TARGET_DIR=<crate>/target`
    on every `fdev build`. Without this, a workspace dep bump
    silently rotates contract WASM bytes and IDs, orphaning every
    user's stored state.
  - **Contract ID reproducibility caveat** — signed-payload version is
    a unix timestamp at signing time, so IDs are NOT reproducible
    from source; the committed `contract-id.txt` / `facade-id.txt`
    are authoritative.
  - **`fdev` / `freenet` install from release tag** vs `cargo install`
    — pins API surface (matters for the `--as-state` flag).
  - **Pre-commit hook** blocking stray `.wasm` outside
    `published-contract/` and requiring `*-id.txt` co-staged with
    every WASM change.

- `skills/dapp-builder/references/contract-patterns.md`
  - **Chained-migration recipe** as alternative to River's
    `OptionalUpgrade` pointer model — append-only
    `LEGACY_*_CODE_HASHES`, `pending_migration_from` retry marker on
    the delegate, recipient WASM hash captured at contact import,
    `current_hash_not_in_legacy` test invariant. For per-user state
    with no shared owner (e.g. an inbox), this is the model that
    works.

- `skills/dapp-builder/references/production-smoke-testing.md`
  - **Four Freenet dApp test tiers** (rust / offline / iso / liveness)
    with a table of what each catches and misses, so a project doesn't
    ship thinking a liveness smoke covers real round-trip behavior.

- `skills/local-dev/SKILL.md`
  - **Isolated multi-node harness pattern** — `--config-dir` per node
    (NOT `--data-dir`) is what isolates `config.toml` and transport
    keypairs. On CI runners with `XDG_CONFIG_HOME` set, the `HOME=…`
    override is bypassed; `--config-dir` is the only flag that wins.

- `skills/systematic-debugging/SKILL.md`
  - **Assert on structured tracing fields** (`phase="…"`) instead of
    removed wire markers (`UPDATE_PROPAGATION`, etc.) — older grep
    patterns now silently pass forever, giving false greens.
  - **Quarantine upstream bugs with skip-with-reason**, do not remove
    the test or weaken the assertion.

- `skills/dapp-builder/SKILL.md`
  - New Phase 4 steps + cross-links to `facade-pattern.md` and
    lockfile-isolation guidance.
  - Updated Phase 1 migration step to point at the chained-migration
    alternative.

- `CHANGELOG.md` + `marketplace.json` — v1.3.0.

## Test plan

- [ ] CI version-bump gate passes (marketplace.json bumped 1.2.3 → 1.3.0)
- [ ] Skill markdown renders cleanly in Claude Code
- [ ] Cross-links between SKILL.md and references resolve
- [ ] `references/facade-pattern.md` reads correctly as a standalone reference
- [ ] No regressions to existing recipes in modified files

[AI-assisted - Claude]