### PR TITLE
fix(pr-review): fall back to diverse Claude lenses when external models are down

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.5.0"
+    "version": "1.5.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ All notable changes to this project will be documented in this file.
   diverse-Claude-lens pass (at least three independent adversarial lenses,
   per `~/.claude/rules/multi-model-review.md`) and records the substitution
   in the posted review. Previously the skill described only the external pass
-  with no documented behavior when it could not run.
+  with no documented behavior when it could not run. Also: prefer waiting for
+  the external model when the change isn't time-sensitive and the quota reset
+  is near, and run the lenses serially within your own context when you can't
+  spawn subagents (background / dispatched agents without the Agent/Task tool).
 
 ## 1.5.0 (2026-06-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.5.1 (2026-06-09)
+
+- `pr-review`: Step 3 now specifies a fallback when external models are
+  unavailable. If `codex` fails, try `gemini`; if both are down (quota /
+  capacity / outage), the review no longer fails — it substitutes a
+  diverse-Claude-lens pass (at least three independent adversarial lenses,
+  per `~/.claude/rules/multi-model-review.md`) and records the substitution
+  in the posted review. Previously the skill described only the external pass
+  with no documented behavior when it could not run.
+
 ## 1.5.0 (2026-06-05)
 
 - `dapp-builder`: added `references/upgrade-and-migration.md` — the operational

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -138,6 +138,36 @@ codex review --base "origin/$BASE"
 Full review of a high-risk PR, add a third independent model when one is available —
 e.g. a `gemini-cli-review` skill or the `gemini` CLI.
 
+### When external models are unavailable — fall back, never skip
+
+External reviewers go down (quota exhaustion, capacity limits, API outages). If
+`codex` fails, try `gemini`; if **both** are genuinely unavailable, do **not** skip the
+independent pass and do **not** fail the review. A `codex review` that returns no
+findings summary, errors out, or reports exhausted budget counts as unavailable — retry
+once, then treat it as down.
+
+Substitute a **diverse-Claude-lens** pass (per `~/.claude/rules/multi-model-review.md`).
+A single extra Claude reviewer is not enough — it shares the author model's blind spots,
+which is the whole reason the external pass exists. Instead spawn **at least three**
+independent reviewers, each with a DISTINCT adversarial lens and each blind to the
+others, scaling to 4–5 for a Full-tier high-risk change:
+
+- *skeptical bug-hunt* — assume bugs exist; hunt races, edge cases, failure modes.
+- *code-first* — read the code before the PR description; flag intent/impl mismatches.
+- *the failure mode specific to THIS change* — e.g. for a wire/protocol change:
+  compat + serialization; for auth: authz bypass; for a migration: data-loss / rollback.
+
+These can be the existing reviewer subagents plus extra adversarial lenses, or
+`general-purpose` subagents with explicit lens prompts. Each reads the actual
+checked-out code and is told NOT to rubber-stamp. Synthesize them the same way as
+Step 5.
+
+**Record the substitution in the posted review:** which external models you tried, the
+exact failure (quota / capacity / outage), that you used the Claude-lens fallback, and
+which lenses ran — so a reader can see that independent review happened and why it took
+this form. When the external models come back before merge and the change is high-risk,
+prefer running the real external pass too rather than relying on the fallback alone.
+
 ## Step 4: Freenet Bug-Pattern Check
 
 Do this for **Full** reviews, and for **Light** reviews whose change has non-trivial

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -146,6 +146,8 @@ independent pass and do **not** fail the review. A `codex review` that returns n
 findings summary, errors out, or reports exhausted budget counts as unavailable — retry
 once, then treat it as down.
 
+**Prefer waiting when you can.** If the change is not time-sensitive and the external quota reset is near (within a few hours, or by the next working session), prefer to **wait** for the external model and note the blockage on the PR — that preserves the strongest signal. Fall back to the Claude-lens pass only when waiting isn't practical (the reset is far off, the change is needed sooner, or the user asked you to proceed).
+
 Substitute a **diverse-Claude-lens** pass (per `~/.claude/rules/multi-model-review.md`).
 A single extra Claude reviewer is not enough — it shares the author model's blind spots,
 which is the whole reason the external pass exists. Instead spawn **at least three**
@@ -161,6 +163,8 @@ These can be the existing reviewer subagents plus extra adversarial lenses, or
 `general-purpose` subagents with explicit lens prompts. Each reads the actual
 checked-out code and is told NOT to rubber-stamp. Synthesize them the same way as
 Step 5.
+
+**If you cannot spawn subagents** (you are yourself a background or dispatched agent without the Agent/Task tool), do not skip and do not fail the review: run the lenses **serially within your own context** instead — one distinct adversarial pass after another (not a single combined read), then synthesize. Serial-within-self is the required fallback whenever spawning subagents is unavailable.
 
 **Record the substitution in the posted review:** which external models you tried, the
 exact failure (quota / capacity / outage), that you used the Claude-lens fallback, and


### PR DESCRIPTION
## Problem

The `pr-review` skill's Step 3 (external model pass) described running `codex` (and optionally `gemini`) but said nothing about what to do when those external models are unavailable — quota exhaustion, capacity limits, or API outages. In that situation an agent following the skill could either silently skip the independent non-Claude pass (losing the highest-value reviewer, whose blind spots don't correlate with Claude-authored code) or fail the review outright.

This came up while building an autonomous issue-dispatch workflow where Codex/Gemini may be temporarily out of usage.

## Approach

Add a "When external models are unavailable" subsection to Step 3 that codifies the fallback already mandated by `~/.claude/rules/multi-model-review.md`:

- If `codex` fails, try `gemini`; only if **both** are genuinely down, fall back.
- Fallback is **not** one extra Claude reviewer (shares the author model's blind spots) but **>=3 independent diverse adversarial lenses** (skeptical bug-hunt, code-first intent/impl mismatch, and the failure mode specific to the change), scaling to 4-5 for Full/high-risk.
- Never skip independent review; never fail the review just because an external model is down.
- Record the substitution in the posted review (which models tried, exact failure, lenses run) so it's auditable.

## Testing

Documentation/instructions-only change to a skill. Version bumped to 1.5.1 and CHANGELOG updated (CI enforces the version bump when skills change).

[AI-assisted - Claude]