### PR TITLE
docs: document WS_API_PORT override and wbg onerror noise (#23)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.5.1"
+    "version": "1.5.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.5.2 (2026-06-21)
+
+Finish absorbing the freenet-email v0.1.x publish/debug lessons (issue #23).
+Patterns 1, 3, and 4 from that issue landed earlier (PRs #34/#35/#36); this
+fills the two remaining "pattern 2" gaps:
+
+- `local-dev`: documented the `WS_API_PORT` environment variable for
+  targeting a non-default node when publishing through a `cargo-make`
+  `publish-*` task (which has no `--port` flag). Notes the unhelpful
+  `put failed after 4 attempts` failure mode of a misdirected cargo-make
+  publish.
+- `dapp-builder` (`references/production-smoke-testing.md`): documented the
+  wasm-bindgen `onerror` shim crash (`imported JS function that was not
+  marked as 'catch' threw an error: expected a string argument, found
+  undefined`) as known-benign console noise from the gateway WebSocket
+  bridge. Explains why the smoke test gates on a curated
+  `FATAL_CONSOLE_PATTERNS` allowlist instead of asserting
+  `consoleErrors === []`, and to leave this message out of the fatal list.
+
 ## 1.5.1 (2026-06-09)
 
 - `pr-review`: Step 3 now specifies a fallback when external models are

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -232,10 +232,28 @@ throws. It surfaces during normal operation, not just on a real failure.
 This is the reason the smoke test gates on a curated `FATAL_CONSOLE_PATTERNS`
 allowlist rather than asserting `consoleErrors === []` — a blanket
 "no console errors" assertion will fail against this noise on every run. Do
-**not** add a regex for this message to `FATAL_CONSOLE_PATTERNS`. If you must
-silence it at the source, mark the relevant `web_sys` import with `--catch`;
-otherwise leave it as benign noise until wasm-bindgen fixes the handler
-upstream.
+**not** add a regex for this message to `FATAL_CONSOLE_PATTERNS`.
+
+One caveat about the recipe above: the `FATAL_CONSOLE_PATTERNS` allowlist
+only filters the `page.on("console", ...)` sink. The `page.on("pageerror",
+...)` handler pushes **every** uncaught exception unconditionally. wasm-bindgen
+catches this thrown value internally and reports it via `console.error`, so in
+practice it lands in the `console` sink (where the allowlist applies), not
+`pageerror`. But if you observe it reaching `pageerror` in your environment,
+filter it there too — otherwise the benign crash still fails the test:
+
+```ts
+page.on("pageerror", (err) => {
+  const text = String(err);
+  // wasm-bindgen onerror shim crash from the gateway WS bridge — benign noise.
+  if (/not marked as 'catch'.*expected a string argument, found undefined/.test(text)) return;
+  fatalErrors.push(text);
+});
+```
+
+If you would rather silence it at the source, mark the relevant `web_sys`
+import with `--catch`; otherwise leave it as benign noise until wasm-bindgen
+fixes the handler upstream.
 
 ### Wiring It In
 

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -214,6 +214,29 @@ has a known-benign error at startup, it stays out of the fatal list by
 default; if a new error category appears that you want to gate on, add a
 regex.
 
+### Known-benign noise: the wasm-bindgen `onerror` shim crash
+
+A dApp loaded inside the gateway iframe will emit a recurring console error
+that is **benign** and must not be gated on:
+
+```
+wasm-bindgen: imported JS function that was not marked as 'catch' threw an
+error: expected a string argument, found undefined
+```
+
+Cause: the shell's WebSocket bridge dispatches a bare `new Event('error')`
+(no `filename`/`message` fields). wasm-bindgen's generated `onerror` handler
+reads `event.filename`, gets `undefined`, and the un-`catch`-marked import
+throws. It surfaces during normal operation, not just on a real failure.
+
+This is the reason the smoke test gates on a curated `FATAL_CONSOLE_PATTERNS`
+allowlist rather than asserting `consoleErrors === []` — a blanket
+"no console errors" assertion will fail against this noise on every run. Do
+**not** add a regex for this message to `FATAL_CONSOLE_PATTERNS`. If you must
+silence it at the source, mark the relevant `web_sys` import with `--catch`;
+otherwise leave it as benign noise until wasm-bindgen fixes the handler
+upstream.
+
 ### Wiring It In
 
 - **`playwright.config.ts`** — set `use.baseURL` to the same URL you put in

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -179,6 +179,20 @@ on a fresh publish to the test node, because the system node has stale
 contract state from a previous run signed by a different key. If you see
 this on a "fresh" test, check which node `fdev` actually hit.
 
+When a publish runs through `cargo-make` (e.g. a `publish-*` task) rather
+than `fdev` directly, there is no `--port` flag to pass — the task hardcodes
+the default port internally. Override it with the `WS_API_PORT` environment
+variable instead:
+
+```bash
+# Targets the isolated test node on 7510 instead of the default 7509
+WS_API_PORT=7510 cargo make publish-myapp
+```
+
+The failure mode for a misdirected `cargo-make` publish is the unhelpful
+`put failed after 4 attempts`, which gives no hint that the port was wrong —
+so set `WS_API_PORT` whenever the target node isn't on 7509.
+
 #### `--data-dir` does NOT isolate `config.toml` either — use `--config-dir` per node
 
 Two `freenet` processes on the same host that pass the same (or default)


### PR DESCRIPTION
## Problem

Issue #23 captured nine debugging lessons from the freenet-email v0.1.x
publish/identity work. Most have already been absorbed into the skills —
the gateway iframe + WS-origin/URL-derivation pattern (PR #35, now in
`dapp-builder/references/ui-patterns.md`), `fdev --port` targeting and the
isolation pitfalls (PR #34), and the broader dApp-practice sync (PR #36).

Two concrete "pattern 2" footguns were still undocumented:

1. **`WS_API_PORT`** — when a publish goes through a `cargo-make`
   `publish-*` task instead of `fdev` directly, there's no `--port` flag;
   the only way to target a non-default node is the `WS_API_PORT` env var.
   Missing this gives the unhelpful `put failed after 4 attempts` with no
   hint that the port was wrong.
2. **The wasm-bindgen `onerror` shim crash** — the gateway's WebSocket
   bridge dispatches a bare `new Event('error')`, and wasm-bindgen's
   generated `onerror` handler reads `event.filename` (undefined) and
   throws `imported JS function that was not marked as 'catch'...`. It
   fires during normal operation, so a smoke test asserting
   `consoleErrors === []` flakes on every run.

## Approach

Minimal, targeted additions placed where a reader is already looking for
that information — no new sections elsewhere, no duplication of patterns
1/3/4 that already landed:

- `skills/local-dev/SKILL.md` — `WS_API_PORT` note appended to the existing
  "`fdev` defaults to port 7509" subsection (the port-targeting context).
- `skills/dapp-builder/references/production-smoke-testing.md` — a
  "Known-benign noise" subsection right after the existing
  `FATAL_CONSOLE_PATTERNS` discussion, explaining why the allowlist exists
  and that this message must stay off the fatal list.

Verified before writing: `WS_API_PORT` appeared nowhere in `skills/`, and
the only prior `onerror` hit was an unrelated `ExecutionError` table row.

## Testing

Docs/markdown only — no Rust build. CI gate is the `version-check`
workflow: `marketplace.json` bumped `1.5.1 → 1.5.2` (PATCH) and a matching
`CHANGELOG.md` entry added, both committed with the skill changes.

## Review

Light-tier docs change. External-model review run before requesting merge
(see PR comment).

## Fixes

Closes #23

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)