### PR TITLE
docs(dapp-builder): consolidated, discoverable "painless path" upgrade playbook (v1.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.7.0"
+    "version": "1.8.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.0 (2026-07-12)
+
+Make the `dapp-builder` **upgrade** knowledge discoverable and consolidated, so a
+future agent (or dev) prompted "upgrade my Freenet dApp" / "bump stdlib" / "ship
+contract v2" lands on ONE clear, complete playbook and does not fall into the
+"recreate everything / dead invites" trap. The v1.6.0/v1.7.0 corrections fixed the
+*framing*; this release fixes *discoverability + completeness*. Grounded in River's
+live 0.6→0.8 stdlib re-key (verified 2026-07-12): rooms auto-migrated on refresh,
+invites survived, the 78-member Official room stayed intact, no recreation.
+Refs freenet-core#2776.
+
+- `SKILL.md` frontmatter **description**: added upgrade/migration to the routing
+  triggers ("upgrade an existing dApp — bump freenet-stdlib, ship a new
+  contract/delegate version (v2), fix a bug that re-keys the WASM, or migrate state
+  across a key change without breaking invites or losing data"). The skill had deep
+  upgrade content but the description advertised only *new*-dApp use cases, so an
+  agent asked to upgrade might not be routed here.
+- `SKILL.md` Development Workflow: added a prominent "Already shipped v1 and here to
+  UPGRADE?" signpost routing straight to the consolidated playbook, so the upgrade
+  path is not buried across Phase 1 / Phase 2 / Phase 4 steps.
+- `upgrade-and-migration.md`: added the consolidated **"Upgrading a Freenet dApp —
+  the painless path"** playbook as the discoverable hub — six numbered steps tying
+  together the v1 design precondition (choose a **stable identity anchor
+  independent of the WASM** — never expose the raw contract key as identity; the
+  anchor options are owner/user key [e.g. River], a fixed namespace/singleton
+  params, a DID, or an index contract — this is general, NOT owner-key-only),
+  reproducible builds (commit lockfile, pin toolchain), register
+  the outgoing code hash BEFORE changing the WASM (`cargo make add-migration` /
+  `add-room-contract-migration`), the `freenet-migrate` crate (crates.io v0.1.0)
+  for the carry-forward, publish + per-client auto-migrate on next load, and the
+  explicit "do NOT recreate instances / rotate keys / warn of dead invites"
+  (recreation is only for a deliberate owner-identity change). Honest caveats kept:
+  self-authorizing + backward-compatible state OR a written carry-forward;
+  per-client on next load; a fresh device has no local state. The existing
+  deep-dives (contract/delegate patterns, five-properties discipline, test harness)
+  remain as references the playbook links to — no duplication.
+
 ## 1.7.0 (2026-07-12)
 
 Reframe the `dapp-builder` contract/delegate **upgrade** guidance so third-party

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dapp-builder
-description: Build decentralized applications on Freenet using river as a template. Guides through designing contracts (shared state), delegates (private state), and UI. Use when user wants to create a new Freenet dApp, design contract state, implement delegates, or build a Freenet-connected UI.
+description: Build and maintain decentralized applications on Freenet using river as a template. Guides through designing contracts (shared state), delegates (private state), and UI, and through upgrading a live dApp safely. Use when user wants to create a new Freenet dApp, design contract state, implement delegates, build a Freenet-connected UI, OR upgrade an existing dApp — bump freenet-stdlib, ship a new contract/delegate version (v2), fix a bug that re-keys the WASM, or migrate state across a contract/delegate key change without breaking invites or losing data.
 license: LGPL-3.0
 ---
 
@@ -81,7 +81,19 @@ Freenet solves "Eventual Consistency" using a specific mathematical requirement:
 
 ## Development Workflow
 
-Follow these phases in order:
+Follow these phases in order.
+
+> **Already shipped v1 and here to UPGRADE?** (bump `freenet-stdlib`, ship a new
+> contract/delegate version, or fix a bug that re-keys the WASM) — go straight to
+> **`references/upgrade-and-migration.md` → "Upgrading a Freenet dApp — the painless
+> path"**, the single start-to-finish playbook. A routine WASM/stdlib bump is
+> **low-risk and mechanical when you designed for it at v1**, not "recreate
+> everything and all invites die" — River's live 0.6→0.8 stdlib re-key (verified
+> 2026-07-12) auto-migrated every room on refresh, kept every invite and the
+> 78-member Official room intact, and needed no recreation. The phases below build
+> a *new* dApp; the playbook ties the upgrade steps together (v1 design
+> precondition → reproducible builds → register the outgoing hash → `freenet-migrate`
+> → publish → do NOT recreate instances or warn of dead invites).
 
 ### Phase 1: Contract Design (Shared State)
 
@@ -101,7 +113,7 @@ Start by listing each *kind* of shared state your app needs — each kind become
 3. Implement `ContractInterface` trait for the contract
 4. Ensure all state updates satisfy the commutative monoid requirement
 5. **Every field in state must be covered by a cryptographic signature** -- contracts run on untrusted peers who can modify unsigned fields. Write a test for each signed field verifying that tampering causes verification failure. See contract-patterns.md for versioned signature patterns when adding fields later.
-6. **Plan contract upgrade from v1 — it's low-risk and mechanical when you design for it.** A WASM change moves the contract key, but if you anchor identity on a stable owner/user key (never on the contract key) the upgrade is transparent to users: state migrates itself on next load, and every owner-key-derived reference (invites, share links, membership, external services keyed on the owner identity) survives the re-key because the client re-derives the new contract key from the *unchanged owner key*, not from a stored contract key. Invites and links do **not** die on an upgrade — River's 0.6→0.8 re-key on the live network kept every room and invite. Recreation is only for deliberately changing the *owner* identity, never for a routine contract/stdlib bump. The shipped baseline (River #292, Delta) is a **backward probe from a committed legacy-code-hash registry**: reconstruct each predecessor key from `(stable params ‖ old code_hash)`, GET the old state, fold it forward, and re-PUT under the current key — permissionless because the successor's `validate_state` re-verifies every byte. The one required operational step is registering the *outgoing* code hash in the registry before the WASM changes, then republishing. An author-signed `OptionalUpgrade` pointer is an *optional* straggler courtesy on top, not the mechanism that moves state. Prefer the reusable `freenet-migrate` crate (published on crates.io as v0.1.0) over hand-rolling. See `contract-patterns.md` → "Contract WASM Upgrade & State Migration". For the cross-cutting operational discipline that keeps the migration itself from losing data (resumable, idempotent, non-destructive, regression-gated, observable), see `upgrade-and-migration.md`.
+6. **Plan contract upgrade from v1 — it's low-risk and mechanical when you design for it.** A WASM change moves the contract key, but if you anchor your app's durable references on a **stable identity anchor that is independent of the WASM** — never the raw contract key — the upgrade is transparent to users: state migrates itself on next load, and every reference derived from that anchor (invites, share links, membership, external services) survives the re-key because the client re-derives the new contract key from the *unchanged anchor*, not from a stored contract key. What the anchor *is* depends on the app (an owner/user key — e.g. River; a fixed namespace/singleton params; a DID; or an index contract mapping a stable name → current key); the options are in `upgrade-and-migration.md` step 1. Invites and links do **not** die on an upgrade — River's 0.6→0.8 re-key on the live network kept every room and invite. Recreation is only for deliberately changing the app's *identity anchor* (e.g. rotating a compromised owner key), never for a routine contract/stdlib bump. The shipped baseline (River #292, Delta) is a **backward probe from a committed legacy-code-hash registry**: reconstruct each predecessor key from `(stable params ‖ old code_hash)`, GET the old state, fold it forward, and re-PUT under the current key — permissionless because the successor's `validate_state` re-verifies every byte. The one required operational step is registering the *outgoing* code hash in the registry before the WASM changes, then republishing. An author-signed `OptionalUpgrade` pointer is an *optional* straggler courtesy on top, not the mechanism that moves state. Prefer the reusable `freenet-migrate` crate (published on crates.io as v0.1.0) over hand-rolling. See `contract-patterns.md` → "Contract WASM Upgrade & State Migration". For the cross-cutting operational discipline that keeps the migration itself from losing data (resumable, idempotent, non-destructive, regression-gated, observable), see `upgrade-and-migration.md`.
 7. **Read `state-authorization-patterns.md` before designing the second iteration.** It captures cross-cutting patterns (per-item vs bundled signatures, replay protection via monotonic counter / tombstones / cross-context binding, signed-payload hygiene, `time::now()` gotchas, related-contracts limits, wire-format stability) that bite on every contract beyond the trivial.
 
 References:

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -1,12 +1,117 @@
 # Upgrading Contracts and Delegates Safely
 
-The *mechanics* of an upgrade — where the new version lives, how to register old
-WASM hashes — are in `contract-patterns.md` ("Contract WASM Upgrade & State
+This is the hub for upgrading a live Freenet dApp. The **painless-path playbook**
+below is the start-to-finish procedure; the rest of the document is the
+operational discipline behind it (the five properties that keep a migration from
+losing data, the test harness, and rollout mechanics). The per-component
+*mechanics* live in `contract-patterns.md` ("Contract WASM Upgrade & State
 Migration") and `delegate-patterns.md` ("Delegate WASM Upgrade & Secret
-Migration"). This document is the **operational discipline** that keeps the
-migration itself from losing user data. Every lesson here was paid for in
-production by River (freenet/river#345, #352, #253). Read it before your *second*
-release, and design for it before your *first*.
+Migration"), which the playbook links to. Every lesson here was paid for in
+production by River (freenet/river#345, #352, #253, #204, #393). Read it before
+your *second* release, and design for it before your *first*.
+
+## Upgrading a Freenet dApp — the painless path
+
+**If you are here to upgrade an existing dApp — bump `freenet-stdlib`, ship a new
+contract or delegate version, or fix a bug that changes the WASM — start here.**
+
+A routine WASM/stdlib bump is **low-risk and mechanical when you designed for it
+at v1.** It is NOT "recreate everything and all invites die." River's live 0.6→0.8
+stdlib re-key (verified 2026-07-12) migrated every room on the next refresh, kept
+every invite and share link working, and left the 78-member Official room intact —
+with no recreation. The property that makes this work: the contract key moves on
+any WASM change, but your app's durable references were anchored to a **stable
+identifier that does not move with the WASM** (River's rooms anchor on the owner's
+verifying key; other designs use a fixed namespace, a DID, or an index contract —
+see step 1), so clients re-derive the new contract key and every reference keeps
+pointing at the right place.
+
+The whole procedure, start to finish:
+
+1. **(Design precondition — done once at v1; verify it still holds.) Choose a
+   stable identity anchor that is independent of the WASM; never expose the raw
+   content-addressed contract key as your app's identity.** A WASM / dependency /
+   compiler change re-derives the contract key, so any durable reference that
+   hard-codes it — invites, share links, bookmarks, membership records,
+   external-service keys, index/registry entries, anything users or other systems
+   hold onto — breaks on upgrade. Anchor those references on something that does
+   **not** change when the WASM re-keys, and keep a way to locate/migrate state
+   from the old key to the new one (steps 3–5). What the stable anchor *is* depends
+   on your app's design — pick one that fits:
+   - a **user/owner public key** — *e.g. River*: invites embed the room owner's
+     verifying key, and the client re-derives the room contract key from it. Fits
+     apps that have a natural owner or per-user identity; not every app does.
+   - a **fixed, well-known parameter / namespace / name** — a "singleton" contract
+     whose params are stable, so its address only moves when the WASM does (and the
+     carry-forward in steps 3–5 handles that move).
+   - a **DID or other external identifier** your app already trusts.
+   - an **index/registry contract** mapping a stable name → the current contract
+     key — a level of indirection. (The index contract itself needs this same
+     treatment: its own address must be reachable via a stable anchor.)
+
+   If v1 exposed a raw contract key as an identifier, fix *that* first — an upgrade
+   cannot rescue an identifier that moves with the WASM. See
+   `identity-and-addressing.md` and "Architecture invariants" below.
+
+2. **Make the build reproducible, so the key moves only when you mean it to.**
+   Commit `Cargo.lock`, pin the toolchain (`rust-toolchain.toml`), build
+   `--locked`. Otherwise a stray `cargo update` or a different rustc silently
+   re-keys the contract and orphans data with no upgrade in sight (River's
+   `Cargo.lock` was gitignored — freenet/river#393). See `build-system.md` →
+   "Byte-reproducibility" and "Hash + artifact hygiene" below.
+
+3. **BEFORE you change the WASM, register the *outgoing* code hash in the legacy
+   registry.** This is the one required operational step and the single most
+   commonly forgotten one. Record the hash the *current* release ships — while it
+   is still the committed WASM — so the new client can find and carry state forward
+   from it. River does this with `cargo make add-migration` (delegate) and
+   `cargo make add-room-contract-migration` (room contract), which append the old
+   `code_hash`/key to `legacy_delegates.toml` / `common/legacy_room_contracts.toml`
+   *before* the new WASM is committed; a pre-commit hook plus the `check-migration`
+   / `check-room-contract-migration` CI tasks block any WASM change that skips it.
+   Your app builds the equivalent registry + guard, or gets both from
+   `freenet-migrate` (next step). Order matters: register first, then rebuild.
+
+4. **Use the `freenet-migrate` crate for the carry-forward instead of hand-rolling
+   it.** The legacy-hash registry, the `build.rs` codegen, the backward probe, and
+   the preconditions-as-types are identical across every app, so `freenet-migrate`
+   packages them. It is **published on crates.io as v0.1.0**: `cargo add
+   freenet-migrate` (runtime carry-forward) and `cargo add --build
+   freenet-migrate-build` (build.rs codegen + CI hash-guard). Honest caveat: v0.1.0
+   targets stdlib 0.8.x and does the *contract*-side carry-forward; the
+   node-mediated transport into a predecessor *delegate* is a documented stub, so
+   delegate secret migration still runs the River/Delta way (the app re-runs the
+   old delegate WASM over `DelegateRequest::ApplicationMessages`). See
+   `contract-patterns.md` and `delegate-patterns.md` for the mechanics it codifies.
+
+5. **Publish the new version, then let clients migrate themselves.** Publish the
+   new WASM to the shared production key **from `main` only**, after review and
+   green CI (every publish hits the same shared address). Each client, on its
+   **next load**, computes old-key vs new-key, GETs the old state, and re-PUTs it
+   under the new key — the successor's `validate_state` re-verifies every byte, so
+   *any* client can carry the state forward and the owner need not be online.
+   Migration is **per-client, lazily, on next load**; old and new clients coexist
+   for an unbounded rollout window. A **fresh device has no local state to
+   migrate** — that is normal, not a failure. Keep the migration itself safe
+   (idempotent, resumable, non-destructive, regression-gated, observable) per "The
+   five properties" below.
+
+6. **Do NOT recreate instances, rotate keys, or warn users their invites are
+   dead.** None of that is part of a routine upgrade, and doing it *causes* the
+   loss you were trying to avoid. Recreation — a genuinely new contract instance and
+   fresh references — is **only** for a deliberate change of the app's *identity
+   anchor* itself (e.g. rotating a compromised owner key, or standing up a genuinely
+   separate instance), never for a contract or stdlib bump.
+
+**What makes it painless is two things holding together:** (1) a stable identity
+anchor independent of the WASM (step 1) so references survive the re-key, and
+(2) state the successor can carry forward on its own. The second means either **self-authorizing + backward-compatible state**
+(so any client can re-PUT it and the new `validate_state` accepts it), OR a
+**written carry-forward** via `freenet-migrate` / the backward probe. With those in
+place the steps above are mechanical. Without them an upgrade is genuinely risky —
+so the fix is to add them, not to recreate everything. The honest caveats stand:
+migration is per-client on next load, and a fresh device has no local state to
+carry forward.
 
 ## The one truth that shapes everything
 


### PR DESCRIPTION
## Problem

The `dapp-builder` skill has deep, correct upgrade/migration content (v1.6.0/v1.7.0 already fixed the *framing* — a routine WASM/stdlib bump is low-risk and mechanical, not "recreate everything and all invites die"). But two gaps remained:

1. **Discoverability.** The skill's frontmatter `description` — the routing trigger — advertised only *new*-dApp use cases. An agent prompted "upgrade my Freenet dApp" / "bump stdlib" / "ship contract v2" might not be routed here at all.
2. **Consolidation.** The upgrade knowledge was scattered across `SKILL.md` Phase 1 / Phase 2 / Phase 4 steps and four reference files (`contract-patterns.md`, `delegate-patterns.md`, `upgrade-and-migration.md`, `build-system.md`). There was no single start-to-finish playbook an agent would land on.

Field-validated grounding (2026-07-12): River's live 0.6→0.8 stdlib re-key was transparent — rooms auto-migrated on refresh, invites survived, the 78-member Official room stayed intact, no recreation needed.

## Approach

- **`SKILL.md` description**: added upgrade/migration to the routing triggers so "upgrade my dApp / bump stdlib / ship a new contract/delegate version / migrate state across a re-key" routes here.
- **`SKILL.md` workflow**: prominent "Already shipped v1 and here to UPGRADE?" signpost routing straight to the playbook.
- **`upgrade-and-migration.md`**: added the consolidated **"Upgrading a Freenet dApp — the painless path"** playbook as the discoverable hub — six numbered steps tying together: (1) the v1 design precondition, (2) reproducible builds, (3) register the outgoing code hash BEFORE changing the WASM (`cargo make add-migration` / `add-room-contract-migration`), (4) the `freenet-migrate` crate (crates.io v0.1.0) for the carry-forward, (5) publish + per-client auto-migrate on next load, (6) do **NOT** recreate instances / rotate keys / warn of dead invites. The existing deep-dives stay as linked references — no duplication.

Per Ian's review while drafting: step 1 leads with the **general** principle — *choose a stable identity anchor independent of the WASM; never expose the raw content-addressed contract key as your app's identity* — and lists the anchor options (owner/user key [e.g. River], fixed namespace/singleton params, DID, or an index/registry contract). River's owner-VK is one illustrative example, **not** the definition (not every Freenet dApp has an owner key).

Honest caveats kept throughout: self-authorizing + backward-compatible state OR a written carry-forward; migration is per-client on next load; a fresh device has no local state.

## Testing

Docs-only. `marketplace.json` bumped 1.7.0 → 1.8.0 (MINOR) + CHANGELOG entry, per the repo's version-bump CI gate. JSON validated.

Refs freenet-core#2776. Not for merge without the usual review pass.

[AI-assisted - Claude]