### PR TITLE
docs(dapp-builder): recommend browser automation for UI validation (v1.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.9.0"
+    "version": "1.9.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.9.1 (2026-07-29)
+
+Recommend browser automation for validating a `dapp-builder` UI *while building
+it*, not only at release time. Playwright was already covered in Phase 4 (the
+post-publish `production-liveness.spec.ts`) and listed as the `offline` tier in
+the test-tier table, but Phase 3 (UI Design), where the UI is actually written,
+said nothing about validating it in a browser and the `offline` tier had no
+recipe anywhere. A Dioxus UI ships as a WASM bundle whose real render path only
+runs in a browser, so without browser automation a UI has no automated coverage
+at all until after publish.
+
+- `SKILL.md` Phase 3: new "Validate the UI in a real browser (both options)"
+  subsection covering Dioxus and TypeScript alike. Drive the UI with Playwright
+  from the first screen onward; gate PRs on the dev-server (`offline`) tier;
+  assert a clean browser console, since WASM panics and CSP blocks surface only
+  as console or network errors; re-run the same flows against the gateway-served
+  webapp (`iso` tier), which needs `frameLocator` and an absolute-URL `goto`.
+  Points at the Playwright MCP browser tools (`local-dev` skill) for interactive
+  debugging, and expands the Phase 3 reference list to include
+  `production-smoke-testing.md`.
+- `references/production-smoke-testing.md`: new "Validating the UI during
+  development (the `offline` tier)" section with a starter `ui-smoke.spec.ts`
+  (mount assertion plus one real interaction plus console-error gate) and the two
+  WASM-specific gotchas: wait on rendered content rather than `page.goto`
+  resolving, and make sure the run is testing the current build rather than a
+  stale `dx serve` bundle.
+
 ## 1.9.0 (2026-07-21)
 
 Update the `dapp-builder` upgrade/migration guidance to match the now-shipped,

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -184,7 +184,40 @@ Best for: web developers, faster iteration, familiar tooling (npm, SCSS, etc.).
 5. For delegate communication, dynamically import internal FlatBuffers types (`ClientRequestT`, `ApplicationMessagesT`, etc.)
 6. Build reactive UI with vanilla TS, or any framework (React, Vue, Svelte)
 
-Reference: `references/ui-patterns.md`
+#### Validate the UI in a real browser (both options)
+
+A Freenet UI's real render path only runs in a browser. A Dioxus UI ships as a
+WASM bundle, so rendering a component tree to a string in a Rust test does not
+exercise the compiled bundle, its event handlers, or its asset paths, and both
+options reach the node over a WebSocket that unit tests never touch.
+**Drive the UI with Playwright (or equivalent browser automation) from
+the first screen onward, not only at release time.** Treat "I built the
+component" as unfinished until a browser has loaded it and a script has clicked
+through it.
+
+1. Serve the UI locally (`dx serve` for Dioxus, `vite dev` for TypeScript) and
+   drive it with Playwright against mock or offline data, so render correctness,
+   navigation, and form validation gate every PR. This is the `offline` tier in
+   `references/production-smoke-testing.md`, which has a starter spec.
+2. Assert the browser console is clean in every flow. WASM panics, failed
+   requests, and CSP blocks surface only as console or network errors, so a UI
+   that looks correct in a screenshot can still be panicking on every
+   interaction.
+3. Once a local node is running, re-run the same flows against the
+   gateway-served webapp (the `iso` tier). Reaching your app there needs
+   `frameLocator` and an absolute-URL `goto`, because the gateway wraps every
+   webapp in an iframe shell.
+
+For interactive debugging rather than scripted specs, the Playwright MCP browser
+tools drive a running `dx serve` or local node directly. See the `local-dev`
+skill, "Debugging with Playwright".
+
+References:
+- `references/ui-patterns.md` - WebSocket connection models, gateway CSP,
+  framework-specific patterns.
+- `references/production-smoke-testing.md` - the four test tiers, the
+  development-loop browser-validation recipe, and the iframe-shell Playwright
+  idioms.
 
 ### Phase 4: Build, Test, and Deploy
 

--- a/skills/dapp-builder/references/production-smoke-testing.md
+++ b/skills/dapp-builder/references/production-smoke-testing.md
@@ -25,6 +25,67 @@ catches what the others catch.
    → cross-identity send via address book). There is no shortcut here;
    `liveness` does not cover it.
 
+## Validating the UI during development (the `offline` tier)
+
+The liveness spec further down runs post-publish. Do not wait for it to find UI
+bugs. The UI you actually ship renders in a browser, and for a Dioxus UI there
+is no unit-test path that runs the compiled WASM bundle at all, so browser
+automation is the first tier that sees the real thing. It belongs in the
+development loop, not the release checklist.
+
+Serve the UI from its dev server and point Playwright straight at it. There is
+no gateway and no iframe shell in this tier, so ordinary `page.locator(...)`
+works and no `frameLocator` is needed.
+
+```ts
+// e2e/ui-smoke.spec.ts
+import { test, expect } from "@playwright/test";
+
+// dx serve / vite dev origin, NOT a /v1/contract/web/... URL.
+const DEV_URL = process.env.UI_DEV_URL ?? "http://127.0.0.1:8080/";
+
+test("app mounts and the first screen is interactive", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  await page.goto(DEV_URL);
+
+  // WASM boot is async: assert on rendered content, never on navigation alone.
+  // `.first()` keeps Playwright's strict mode from failing on a second match.
+  await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Then exercise one real interaction, so a component that renders but whose
+  // handlers never fire is caught too.
+  await page.getByRole("button", { name: /create new identity/i }).click();
+  await expect(page.getByRole("textbox", { name: /display name/i })).toBeVisible();
+
+  expect(errors, `console errors:\n${errors.join("\n")}`).toEqual([]);
+});
+```
+
+What this tier catches that no Rust test can: a WASM bundle that never boots (a
+panic in `main`, a wrong asset path in `Dioxus.toml`), a component that paints
+but whose event handlers are dead, and console errors from assets that resolve
+in dev but are missing from the bundle. Run it on every PR.
+
+Two gotchas specific to a WASM UI:
+
+- **Wait on rendered content, not on navigation.** `page.goto` resolves once the
+  HTML shell loads, well before the WASM bundle has booted and mounted. Always
+  assert on a visible element with a generous timeout.
+- **Make sure you are testing the current build.** `dx serve` rebuilds on a
+  delay, so a Playwright run started too early exercises the previous bundle. In
+  CI, build first and serve the built output instead of relying on the watcher.
+
+The strict `errors.toEqual([])` assertion is safe in this tier because there is
+no gateway shell to emit the benign wasm-bindgen `onerror` noise described
+below. Once the app is published to a local node, run the same flows against the
+gateway URL, where the iframe-shell rules apply and that strict assertion has to
+become the curated `FATAL_CONSOLE_PATTERNS` allowlist.
+
 ## The two production-only pitfalls
 
 Two things break only after `fdev publish`, not in `dx serve` /


### PR DESCRIPTION
## Problem

The `dapp-builder` skill mentioned Playwright, but only for **post-publish** validation:

- Phase 4 step 5: a `production-liveness.spec.ts` run against the deployed gateway URL.
- `production-smoke-testing.md`: an `offline` tier listed in the four-tier table, described but with no recipe anywhere.

**Phase 3 (UI Design), where the UI is actually written, said nothing about validating it in a browser** for either Option A (Dioxus) or Option B (TypeScript + Vite). A Dioxus UI ships as a WASM bundle with no unit-test path that runs the compiled bundle, so following the skill as written left a UI with no automated coverage at all until after publish.

## Approach

Recommend browser automation as part of building the UI, and give the `offline` tier the recipe it was missing. Kept deliberately small: the substance lives in the existing reference file, and Phase 3 points at it rather than repeating it.

- `SKILL.md` Phase 3: new "Validate the UI in a real browser (both options)" subsection. Drive the UI with Playwright from the first screen onward; gate PRs on the dev-server (`offline`) tier; assert a clean browser console, since WASM panics and CSP blocks surface only as console or network errors; re-run the same flows against the gateway-served webapp (`iso` tier), which needs `frameLocator` and an absolute-URL `goto`. Also points at the Playwright MCP browser tools (`local-dev` skill) for interactive debugging, and expands the Phase 3 reference list to include `production-smoke-testing.md`.
- `references/production-smoke-testing.md`: new "Validating the UI during development (the `offline` tier)" section with a starter `ui-smoke.spec.ts` (mount assertion, one real interaction, console-error gate) plus the two WASM-specific gotchas: wait on rendered content rather than on `page.goto` resolving, and do not test a stale `dx serve` bundle.

## Testing

Docs-only change, so no runtime tests. Checks run:

- The starter spec was extracted and type-checked with `tsc --strict` (clean; the only diagnostics were from stubbing out the `@playwright/test` import for the check).
- Verified the new text does not contradict the existing guidance in the same file: the strict `errors.toEqual([])` assertion is called out as safe only in the dev tier, where there is no gateway shell to emit the documented benign wasm-bindgen `onerror` noise, and as needing the curated `FATAL_CONSOLE_PATTERNS` allowlist at the gateway.
- `marketplace.json` bumped to 1.9.1 (PATCH: documentation improvement) with a matching CHANGELOG entry, so `version-check.yml` passes. JSON validated.

[AI-assisted - Claude]