### PR TITLE
docs(dapp-builder): correct two stale claims that misdirect design (v1.11.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.10.5"
+    "version": "1.11.0"
   },
   "plugins": [
     {

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# Agent worktrees live here (.claude/worktrees/<name>). Committing one adds it
+# as an embedded git repo rather than files — easy to do with `git add -A`.
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.11.0 (2026-08-03)
+
+Correct two stale claims that were actively steering readers toward worse
+designs. Both were found while designing ghost-key-gated room membership; both
+had already been overtaken by shipped freenet-core work.
+
+**`delegate-patterns.md` said delegates cannot run background tasks or touch
+contracts.** It listed "create, read and modify contracts", "request user
+permission" and "run background tasks" as *planned but not yet fully
+implemented* — contradicting this skill's own SKILL.md, which describes
+background tasks as a delegate capability. The implemented reality:
+`OutboundDelegateMsg` carries `GetContractRequest`, `PutContractRequest`,
+`UpdateContractRequest`, `SubscribeContractRequest`, `SendDelegateMessage` and
+`RequestUserInput`, each with handlers in freenet-core, and core keeps a
+`DELEGATE_SUBSCRIPTIONS` registry that delivers `ContractNotification` to a
+subscribed delegate when contract state changes — with no UI open. That is the
+long-running background service the doc said did not exist, and the ghostkeys
+delegate already ships the permission-prompt path in production. Only
+*creating* a delegate from within a delegate remains unimplemented.
+
+Consequence of the error: a reader designing anything that needs verification
+too expensive to sit in a contract's validation path would conclude there was
+nowhere to put it, and either abandon the design or reach for a centralized
+server.
+
+**SKILL.md documented freenet-core#4857 as a live limitation.** That issue —
+"State updates permanently lost for rarely-changing fields: silent
+ContractQueueFull drop + sender-side neighbor-summary poisoning" — is CLOSED.
+The section told readers to expect multi-minute staleness on config, permission
+and ban-list fields, and to let important changes "ride alongside a field that
+ships frequently". The shipped fix has the queue-full receiver emit a
+`ResyncRequest` that clears the sender's poisoned summary, throttled to one per
+(contract, peer) per 30s (#4251 showed one-per-dropped-delta amplifies into a
+full-state storm; #4862 hardened it against bridge backpressure).
+
+The genuinely useful part of that section — `BTreeMap` never `HashMap` in
+summary types, because ciborium serializes `HashMap` nondeterministically and
+breaks core's byte-level convergence check — is kept and promoted to its own
+heading, since it stands independently of the bug.
 ## 1.10.5 (2026-08-01)
 
 Warn against unqualified mobile deployment. `SKILL.md` listed the UI's

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -76,17 +76,32 @@ Freenet solves "Eventual Consistency" using a specific mathematical requirement:
 
 **Requirement: `get_state_delta` must not ship state to a peer that already has it.** When the requester's summary shows it holds everything you have, the delta carries no information, so it must not contain the state or approach the state's size. It *should* be a literally empty `StateDelta` (`vec![]`), which is the unambiguous "converged" answer and what `freenet-scaffold` produces for you; a few tens of bytes of encoding framing from serializing an all-empty struct is acceptable. What matters is delta size relative to state size: 20 bytes against a 500 KB state is fine, a state-sized delta is a broken delta mechanism that re-ships everything on every reconciliation, forever. Your summary must likewise be far smaller than your state. Core is adding a probe for contracts that get this wrong, and it currently costs the network real bandwidth. Full detail, code shapes, and a test are in `references/contract-patterns.md` → "The Delta to an Up-to-Date Peer".
 
-### Known limitation: a rarely-changing field can lag between peers
+### Summaries must serialize deterministically
 
-In current Freenet core, a state update to a **rarely-changing field can be silently lost between two peers** and stay missing for a while. When a receiving peer is briefly overloaded it can drop an incoming update without signalling the sender, and the sender then treats that peer as up to date, so it computes later updates as "only newer changes" and never re-sends the dropped one. A slow background heal (roughly every 5 minutes) eventually repairs it, and that heal can itself drop again under load.
+**Use deterministic maps in your `Summary` type: `BTreeMap`, never `HashMap`.** A `HashMap` serializes in nondeterministic order (ciborium), so two identical states can summarize to different bytes and core's byte-level convergence check misfires — spurious heals, or missed ones. The same caution applies to any map inside whatever `summarize` returns.
 
-Fields that change often hide the problem, because their current value re-ships on the next update anyway. A field that changes rarely is where it shows: config, metadata, an authority or permission field, a ban list. Some peers keep serving the stale value until the heal reaches them. This is a current-core limitation, tracked and being fixed in [freenet/freenet-core#4857](https://github.com/freenet/freenet-core/issues/4857).
+Beyond that, make sure your state genuinely converges through `summarize` / `delta` / `apply`, and test that it does, rather than assuming a live broadcast reaches every peer.
 
-Design around it until the fix lands:
-
-- **Use deterministic maps in your `Summary` type: `BTreeMap`, never `HashMap`.** A `HashMap` serializes in nondeterministic order (ciborium), so two identical states can summarize to different bytes and core's byte-level convergence check misfires (spurious heals, or missed ones). This is the single cheapest and most important fix. The same caution applies to any map inside whatever `summarize` returns.
-- **Do not assume a one-shot change to a rarely-updated field reaches every peer instantly.** Make sure your state genuinely converges through `summarize` / `delta` / `apply` (and test that it does) instead of relying on a live broadcast reaching everyone. Where practical, let important changes ride alongside a field that ships frequently.
-- **When debugging "some peers do not see my update," suspect this core limitation before your own `apply` logic.**
+> **Previously documented here as a live limitation, now fixed.**
+> [freenet/freenet-core#4857](https://github.com/freenet/freenet-core/issues/4857)
+> ("State updates permanently lost for rarely-changing fields") is **CLOSED**. A
+> `ContractQueueFull` drop was silent, and the sender cached its own summary as
+> the receiver's on send-Ok, so it believed the peer was current and never
+> re-sent — leaving rarely-changing fields (config, permissions, ban lists)
+> diverged until the ~5-minute InterestSync heartbeat happened to correct them.
+>
+> The shipped fix has the queue-full receiver emit a `ResyncRequest`, which makes
+> the sender clear its poisoned summary and re-send full state. It is throttled to
+> one per (contract, peer) per 30s, because
+> [#4251](https://github.com/freenet/freenet-core/issues/4251) showed that one
+> request per dropped delta amplifies into a full-state storm onto the same
+> saturated queue; [#4862](https://github.com/freenet/freenet-core/pull/4862)
+> hardened it against bridge backpressure. See `RESYNC_REQUEST_MIN_INTERVAL` in
+> `crates/core/src/ring/interest.rs`.
+>
+> Do **not** design around multi-minute staleness on rarely-changing fields, and
+> do not treat a ban list or permission field as needing to ride alongside a
+> frequently-changing one. The earlier guidance to do so is retired.
 
 ## Advanced Capabilities
 

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -28,16 +28,30 @@ impl DelegateInterface for MyDelegate {
 
 ## Delegate Capabilities
 
-**Currently used in River:**
+**Implemented and usable today:**
 - Store private data on behalf of users (secrets, keys, preferences)
-- Send/receive messages from UIs
+- Send/receive messages from UIs, and from *other apps* on the same node
 - Perform cryptographic operations (signing, encryption)
+- **Read, write, and subscribe to contracts** — `OutboundDelegateMsg` carries
+  `GetContractRequest`, `PutContractRequest`, `UpdateContractRequest` and
+  `SubscribeContractRequest`, each with handlers in freenet-core
+- **Request user permission** via `OutboundDelegateMsg::RequestUserInput`; the
+  runtime renders the prompt. The ghostkeys delegate ships this in production
+- **Run as a long-running background service.** A delegate that subscribes to a
+  contract is woken by `InboundDelegateMsg::ContractNotification` whenever that
+  contract's state changes, with no UI open. Core keeps a `DELEGATE_SUBSCRIPTIONS`
+  registry mapping contract → interested delegates
+- Message another delegate on the same node via `SendDelegateMessage`
 
-**Planned but not yet fully implemented:**
-- Create, read, and modify contracts
-- Create other delegates
-- Request user permission for sensitive operations
-- Run background tasks (monitoring, notifications)
+**Still not implemented:**
+- Creating other delegates from within a delegate (no such variant exists on
+  `OutboundDelegateMsg`)
+
+> This list previously described contract access, user permission and background
+> tasks as "planned but not yet fully implemented", which contradicted SKILL.md
+> and steered readers away from the subscription-driven background-service
+> pattern that core actually supports. Verified against freenet-stdlib
+> `delegate_interface.rs` and freenet-core.
 
 ## Message Types
 


### PR DESCRIPTION
Two claims in the dapp-builder skill are out of date, and both push readers toward worse designs. Found while designing ghost-key-gated room membership — I acted on both before checking, and both were wrong.

## 1. `delegate-patterns.md`: delegates *can* run background services

It listed as **"planned but not yet fully implemented"**:
- Create, read, and modify contracts
- Request user permission for sensitive operations
- Run background tasks (monitoring, notifications)

All three are implemented, and the first and third contradict this skill's own SKILL.md ("**Background Tasks:** Can run continuously to monitor contracts or handle notifications even when the UI is closed").

Verified:
- `OutboundDelegateMsg` (freenet-stdlib `delegate_interface.rs`) carries `GetContractRequest`, `PutContractRequest`, `UpdateContractRequest`, `SubscribeContractRequest`, `SendDelegateMessage`, `RequestUserInput` — 8–13 handler sites each in freenet-core.
- Core keeps a `DELEGATE_SUBSCRIPTIONS` registry mapping contract → interested delegates, and delivers `InboundDelegateMsg::ContractNotification` when state changes (`contract.rs:867`). That is the background-service mechanism.
- The ghostkeys delegate ships `RequestUserInput` in production.
- Only *creating a delegate from within a delegate* remains unimplemented — no such variant exists.

**Why it matters:** anyone whose design needs verification too expensive to sit in a contract's validation path reads this and concludes there is nowhere to put it — then either abandons the design or reaches for a centralized server. That is precisely what nearly happened here.

## 2. `SKILL.md`: freenet-core#4857 is fixed, not a live limitation

The section told readers a rarely-changing field can be silently lost and stay stale until a ~5-minute heal, named ban lists and permission fields as the failure case, and advised letting important changes "ride alongside a field that ships frequently".

[freenet-core#4857](https://github.com/freenet/freenet-core/issues/4857) — *"State updates permanently lost for rarely-changing fields: silent ContractQueueFull drop + sender-side neighbor-summary poisoning"* — is **CLOSED**. The queue-full receiver now emits a `ResyncRequest` that makes the sender clear its poisoned summary and re-send full state, throttled to one per (contract, peer) per 30s because [#4251](https://github.com/freenet/freenet-core/issues/4251) showed one-per-dropped-delta amplifies into a full-state storm; [#4862](https://github.com/freenet/freenet-core/pull/4862) hardened it against bridge backpressure. See `RESYNC_REQUEST_MIN_INTERVAL` in `crates/core/src/ring/interest.rs`.

Kept the `BTreeMap`-never-`HashMap` guidance and promoted it to its own heading — ciborium serializes `HashMap` nondeterministically, which breaks core's byte-level convergence check, and that is true independent of the bug.

## Testing

Documentation only. Every claim above was checked against freenet-stdlib and freenet-core source, and the issue states via `gh`.

[AI-assisted - Claude]