### PR TITLE
docs(dapp-builder): document return_path, and the cached-check trap (v1.13.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.12.0"
+    "version": "1.13.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.13.0 (2026-08-03)
+
+Two additions to the ghost key purchase round trip, both from watching the flow
+end to end rather than from reading the API.
+
+**`return_path`.** `return_to` only ever landed a donor on the app's *root*, so
+an app that sent them off from a deep-linked view got them back with their
+place lost. It now takes a relative route alongside the contract id — a
+sub-path, a `#route`, or both — while the vault still synthesises the
+`/v1/contract/web/<id>/` prefix itself, so the route only decides what follows
+and is refused if it could climb out of the contract.
+
+**Do not gate the action on a cached identity check.** This is the failure that
+actually bites in this flow, and it is silent: an app checks `HasIdentity` at
+load, renders "buy a ghost key", the user buys one — and the tab they return to
+is the one that already checked. There is no callback from the vault, and the
+vault opens in a *new* tab, so the original can sit there indefinitely
+insisting they have no key.
+
+The fix is not polling or focus listeners; it is not depending on the cached
+answer. Use `HasIdentity` to decide what to **offer**, never to decide whether
+the user may **attempt**. Let them try, call `SignWithDefault`, and branch on
+the result — it prompts if the app holds no grant and returns
+`NoIdentityAvailable` only when there is genuinely nothing to sign with. An app
+written that way detects nothing, and a stale tab costs one extra click instead
+of dead-ending.
+
 ## 1.12.0 (2026-08-03)
 
 Bring the ghost key integration guidance in line with the delegate published

--- a/skills/dapp-builder/references/identity-and-addressing.md
+++ b/skills/dapp-builder/references/identity-and-addressing.md
@@ -373,6 +373,34 @@ your app. Pass your contract instance id, not a URL -- the vault only ever
 builds a same-origin `/v1/contract/web/<id>/` path from it, and rejects
 anything that is not a valid id.
 
+Add `&return_path=<percent-encoded relative route>` to come back to a specific
+place rather than your app's root -- a sub-path, a `#route`, or both. Encode
+it: it may contain its own `#`, and it is going into a fragment. The vault
+still synthesises the `/v1/contract/web/<id>/` prefix itself, so the route only
+decides what follows, and it is refused if it could climb out of your contract.
+
+### Do not gate the action on a cached identity check
+
+The one thing that reliably goes wrong in this flow: the app checks
+`HasIdentity` once at load, renders "buy a ghost key", the user goes and buys
+one -- and the tab they came back to is still the one that checked. It has no
+idea anything happened. There is no callback from the vault to your app, and
+the vault opens in a **new tab**, so their original tab can sit there
+indefinitely insisting they have no key.
+
+Do not solve this by polling or by listening for focus events. Solve it by not
+depending on the cached answer in the first place:
+
+- Use `HasIdentity` to decide what to **offer** -- whether to surface a
+  buy-a-key path at all.
+- Do **not** use it to decide whether the user may **attempt** the action. Let
+  them try, call `SignWithDefault`, and branch on what comes back.
+
+That works because `SignWithDefault` is authoritative at the moment it matters:
+it prompts if you hold no grant, and returns `NoIdentityAvailable` only when
+there is genuinely nothing to sign with. An app written this way needs to
+detect nothing. A stale tab costs the user one extra click, not a dead end.
+
 Verification can go through the delegate
 (`GhostkeyRequest::VerifySignedMessage`, which returns `VerifyResult` with
 `valid`, `signer_fingerprint`, and the donation metadata), or you can link


### PR DESCRIPTION
Two additions to the ghost key purchase round trip, both from watching the flow end to end rather than from reading the API.

## `return_path`

`return_to` only ever landed a donor on the app's **root**, so an app that sent them off from a deep-linked view got them back with their place lost. It now takes a relative route alongside the contract id — a sub-path, a `#route`, or both ([ghostkeys#18](https://github.com/freenet/ghostkeys/pull/18), live).

The vault still synthesises the `/v1/contract/web/<id>/` prefix itself, so the route only decides what follows, and is refused if it could climb out of the contract.

## Do not gate the action on a cached identity check

This is the failure that actually bites in this flow, and it is silent:

> an app checks `HasIdentity` at load → renders "buy a ghost key" → the user goes and buys one → **the tab they come back to is the one that already checked.**

There is no callback from the vault to the app, and the vault opens in a *new* tab, so their original tab can sit there indefinitely insisting they have no key.

The guidance is deliberately **not** "listen for focus" or "poll":

- Use `HasIdentity` to decide what to **offer** — whether to surface a buy-a-key path at all.
- Do **not** use it to decide whether the user may **attempt** the action. Let them try, call `SignWithDefault`, branch on the result.

That works because `SignWithDefault` is authoritative at the moment it matters: it prompts if the app holds no grant, and returns `NoIdentityAvailable` only when there is genuinely nothing to sign with. An app written that way detects nothing, and a stale tab costs one extra click instead of dead-ending.

### Why not a `visibilitychange` recommendation

I tried to verify one and couldn't. The test showed the sandboxed webapp iframe never receiving the event — but the **control** showed a plain top-level page not receiving it either, so I was measuring headless Chromium's lack of real tab visibility, not anything about the gateway sandbox.

Rather than document an unverified heuristic, the advice removes the dependency entirely. That is the better answer regardless of how the event question resolves, which is also why I stopped chasing it.

[AI-assisted - Claude]