### PR TITLE
docs(dapp-builder): make the stale-delegate-key problem findable (v1.16.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.15.0"
+    "version": "1.16.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.16.0 (2026-08-04)
+
+Make the delegate-reference problem something an agent will actually *find*.
+
+1.15.0 documented it, but only where an agent already reading about delegates
+would look. The people most affected have apps that already work and no reason
+to open that page.
+
+**A grep, at the top of SKILL.md.** An agent picking up an existing Freenet app
+is now told, before anything else, to check whether it hardcodes a platform
+delegate's key — with the command to run. That constant goes stale on every
+re-key of a delegate the app does not own, including a bare version bump, and
+the failure is silent: every request comes back looking like "this user has
+nothing stored".
+
+**How to read client-side delegate errors**, which the skill had never covered.
+`Missing` means the delegate is not registered — almost always a stale
+hardcoded key, and *not* "the user has no data". `ExecutionError` covers rate
+limiting and is transient. Includes the caveat that `Missing` is never proof a
+user has nothing, since `UnregisterDelegate` leaves secrets behind, and a
+version note: up to freenet-core v0.2.119 the websocket layer also emitted
+`Missing` when throttling, so on those nodes the two cannot be told apart at
+all (fixed in freenet-core#5146).
+
+That overloading is why the August 2026 ghostkeys breakage was hard to
+diagnose. The affected app's error handling was correct and still produced a
+misleading message, because the protocol gave it nothing to distinguish an app
+that needed updating from a user who had never bought a key.
+
 ## 1.15.0 (2026-08-04)
 
 Add the consumer side of delegate re-keying, which the skill had never covered.

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -114,6 +114,16 @@ Beyond that, make sure your state genuinely converges through `summarize` / `del
 
 Follow these phases in order.
 
+> **Working on an app that already exists?** Before anything else, check whether
+> it hardcodes a *delegate key* belonging to a platform delegate it does not own
+> (ghostkeys being the one in use today). That constant goes stale on every
+> re-key of that delegate — including a bare version bump — and the failure is
+> silent: every request comes back looking like "this user has nothing stored".
+> One grep, and the fix is a runtime fetch. See
+> `references/delegate-patterns.md` → "Depending on Someone Else's Delegate".
+> This broke every ghostkeys integration in August 2026 and was found by a
+> confused user rather than by any test.
+>
 > **Already shipped v1 and here to UPGRADE?** (bump `freenet-stdlib`, ship a new
 > contract/delegate version, or fix a bug that re-keys the WASM) — go straight to
 > **`references/upgrade-and-migration.md` → "Upgrading a Freenet dApp — the painless

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -365,6 +365,20 @@ If you pass `keyBytes` for both fields (or `codeHashBytes` for both), the node w
 
 ## Depending on Someone Else's Delegate (consumer side)
 
+> **Working on an app that already exists? Check this first.**
+>
+> ```bash
+> # Any of these hits means the app will break silently on the next re-key.
+> grep -rniE "delegate_key|DELEGATE_KEY|delegate_code_hash|ghostkeys.*delegate" \
+>     --include=*.ts --include=*.js --include=*.rs --include=*.json \
+>     --include=*.toml . | grep -v node_modules
+> ```
+>
+> A hit in a build config, a generated constants file, or a `vite.config` /
+> `build.rs` define is the pattern that breaks. Replace it with a runtime fetch
+> (below). This is not theoretical — it silently broke every ghostkeys
+> integration and was found by a confused user, not by any test.
+
 Everything below about migration is written from the *author's* side: your
 delegate re-keys, so migrate your users' secrets forward. There is a second,
 easily-missed half — **you are a consumer of other people's delegates too**, and
@@ -424,6 +438,34 @@ Three rules that matter:
   smaller exposure, not zero: it would move if the *web container contract*
   were upgraded, which is a much larger and more visible event than a delegate
   re-key.
+
+### Reading delegate errors on the client
+
+The client-side `DelegateError` (from `freenet-stdlib`, distinct from the
+`DelegateError` your delegate's `process` returns) is what tells you *why* a
+request did not work. Two variants are worth branching on:
+
+| Variant | Means | What to do |
+|---|---|---|
+| `Missing(key)` | that delegate is **not registered** on this node | almost always a stale hardcoded key. Tell the user the app needs updating, and tell yourself — this is not "the user has no data" |
+| `ExecutionError(msg)` | includes rate limiting after repeated failures | transient. Back off and retry; the message carries the delay |
+
+**Do not treat `Missing` as proof the user has nothing stored.** It is not,
+for a reason that survives even a correct client: `UnregisterDelegate` removes
+a delegate's code while leaving its secrets in place, so a node can report "no
+such delegate" while still holding data under it.
+
+**Version note.** Up to and including freenet-core **v0.2.119**, the websocket
+layer also emitted `Missing` when throttling a client after repeated failures,
+so on those nodes the two are indistinguishable and you should not branch on it
+at all. Fixed in
+[freenet-core#5146](https://github.com/freenet/freenet-core/pull/5146) — from
+the following release, `Missing` means only "not registered".
+
+That overloading is exactly why the ghostkeys breakage was so hard to diagnose:
+the app's error handling was correct and still produced a misleading message,
+because the protocol gave it nothing to distinguish an app that needed updating
+from a user who had never bought a key.
 
 ### If you publish a delegate others depend on
 


### PR DESCRIPTION
v1.15.0 documented the consumer side of delegate re-keying. This makes an agent actually *find* it.

## The gap

1.15.0 put the guidance in `delegate-patterns.md` — where an agent already reading about delegates would look. **The people most affected have apps that already work and no reason to open that page.**

## What's added

**A grep, at the top of `SKILL.md`.** An agent picking up an existing Freenet app is now told, before anything else, to check whether it hardcodes a platform delegate's key — with the command to run:

```bash
grep -rniE "delegate_key|DELEGATE_KEY|delegate_code_hash|ghostkeys.*delegate" \
    --include=*.ts --include=*.js --include=*.rs --include=*.json --include=*.toml . \
    | grep -v node_modules
```

A hit in a build config, generated constants file, or `vite.config` / `build.rs` define is the pattern that breaks.

**How to read client-side delegate errors** — never covered before:

| Variant | Means | Do |
|---|---|---|
| `Missing(key)` | delegate **not registered** | almost always a stale hardcoded key. The app needs updating. **Not** "the user has no data" |
| `ExecutionError(msg)` | includes rate limiting | transient; back off, message carries the delay |

With two caveats that matter:

- `Missing` is **never proof** a user has nothing stored — `UnregisterDelegate` removes a delegate's code while leaving its secrets in place.
- **Up to freenet-core v0.2.119** the websocket layer also emitted `Missing` when throttling, so on those nodes the two are indistinguishable and should not be branched on at all. Fixed in [freenet-core#5146](https://github.com/freenet/freenet-core/pull/5146).

That overloading is precisely why the August 2026 ghostkeys breakage was hard to diagnose: the affected app's error handling was *correct* and still produced a misleading message, because the protocol gave it nothing to distinguish an app needing an update from a user who had never bought a key.

## For users with agents building on Freenet

Once this merges, the instruction is just **"update the freenet plugin"** — `/plugin marketplace update freenet-agent-skills`. Their agent then picks up the audit step on its own.

[AI-assisted - Claude]