### PR TITLE
docs(dapp-builder): serve large binary assets from their own contract

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.16.0"
+    "version": "1.17.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.17.0 (2026-08-04)
+
+Document where large binary assets (audio, video, images, uploads) belong:
+their own contract, not the webapp bundle.
+
+The existing "State Size Budget" guidance already said to shard unbounded
+data by write-concurrency unit, but never spelled out the mechanism for the
+common case of a UI wanting to serve a media file — an agent following only
+"vendor your assets" from the CSP section would reasonably conclude large
+files need to ship inside the webapp bundle too, which hits the 50 MiB hard
+cap fast and forces re-publishing every asset byte on any unrelated UI
+change.
+
+**New section in `ui-patterns.md`**: any contract's non-HTML files are
+servable at `/v1/contract/web/{KEY}/{path}`, and that path is same-origin
+with the UI's own iframe no matter whose key it names, so a UI can embed
+`<audio src="/v1/contract/web/{ASSET_CONTRACT_KEY}/track.mp3">` pointing at
+a *different* contract instance without tripping the gateway CSP. Splitting
+assets out this way also lets demand-driven hosting retain/evict each asset
+independently of the UI contract's own popularity.
+
 ## 1.16.0 (2026-08-04)
 
 Make the delegate-reference problem something an agent will actually *find*.

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -246,7 +246,8 @@ skill, "Debugging with Playwright".
 
 References:
 - `references/ui-patterns.md` - WebSocket connection models, gateway CSP,
-  framework-specific patterns.
+  serving large binary assets from a dedicated contract, framework-specific
+  patterns.
 - `references/production-smoke-testing.md` - the four test tiers, the
   development-loop browser-validation recipe, and the iframe-shell Playwright
   idioms.

--- a/skills/dapp-builder/references/state-authorization-patterns.md
+++ b/skills/dapp-builder/references/state-authorization-patterns.md
@@ -324,6 +324,8 @@ Example for the inbox: `MAX_INBOX_MESSAGES = 1000` × `MAX_CIPHERTEXT_BYTES = 32
 
 **Design target: stay well under 4 MB per instance, regardless of the 50 MiB cap.** The cap is about correctness, not user experience — a GET transfers the entire state before the UI can render anything, so state size is felt directly as load latency, and it's the wire-transfer floor under the streaming behavior described in `ui-patterns.md` → "Large state handling". If a kind of data can grow without bound (message history, uploaded files, a list that only grows), shard by the natural unit of write concurrency — one contract per room, per user, per time-window, per shard-key — so each instance's state stays small no matter how large the dataset gets in aggregate. Treat a multi-MB instance as a signal to split the data model, not to compress harder or budget more cap headroom.
 
+Large *binary* assets served by the UI (audio, video, images, user uploads) are a special case of the same sharding advice, not a new problem: give the asset its own contract instance instead of embedding it in the webapp bundle's state, and reference it from the UI by key. See `ui-patterns.md` → "Large Binary Assets: Their Own Contract, Not the Webapp Bundle" for the same-origin fetch mechanism that makes this work under the gateway CSP.
+
 ## Per-Context Identity Considerations
 
 If your dApp uses **per-context signing keys** (River's pattern: the inviter generates a fresh keypair for each new member, scoped to one room):

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -67,6 +67,37 @@ this regression by asserting `getComputedStyle(...).fontWeight` matches the
 value set by your vendored stylesheet — it flips back to the user-agent
 default the moment the stylesheet fails to load.
 
+### Large Binary Assets: Their Own Contract, Not the Webapp Bundle
+
+Vendoring covers your CSS/JS/fonts, but don't extend that reflex to
+large or unbounded binary assets — audio, video, images, datasets, user
+uploads. Those don't belong in the webapp contract's state at all, for the
+same reason described in `state-authorization-patterns.md` → "State Size
+Budget": state is versioned as a whole, so every byte you embed gets
+re-published and re-transferred on every unrelated UI change, and a GET
+transfers the entire state before the UI can render anything.
+
+The fix isn't to fetch the asset from an external server — the CSP above
+blocks that (`connect-src`/`default-src <iframe-origin>` only). It's to give
+the asset **its own contract instance** and reference it by key from your
+UI. Any contract's non-HTML files are servable at
+`/v1/contract/web/{CONTRACT_KEY}/{path}`, and that path is same-origin
+with your own UI's iframe regardless of whose key it names — the CSP is
+scoped to the gateway's origin, not to a specific contract. So this works
+even though it names a different contract than the one serving the page:
+
+```html
+<audio src="/v1/contract/web/{ASSET_CONTRACT_KEY}/track.mp3"></audio>
+```
+
+A contract used purely as an asset store doesn't need an `index.html` — it
+can just be a bundle of static files addressed by key. Splitting assets out
+this way also decouples their hosting from the UI contract's: Freenet's
+demand-driven hosting retains/evicts each contract instance independently
+based on its own subscriber/access pattern, so an asset contract's
+popularity (or lack of it) no longer forces every peer serving your UI to
+also carry bytes nobody is requesting.
+
 ## Dioxus Setup
 
 ### Project Structure


### PR DESCRIPTION
## Problem
The dapp-builder skill's "Gateway CSP: Vendor Your Assets" section tells agents to vendor CSS/JS/fonts into the webapp bundle, but says nothing about large or unbounded binary assets (audio, video, images, uploads). An agent following only that guidance could reasonably conclude such assets belong in the webapp bundle too, which hits the 50 MiB `MAX_STATE_SIZE` hard cap fast and forces re-publishing every asset byte on any unrelated UI change.

## Approach
Document the actual mechanism that solves this: any contract's non-HTML web assets are served at `/v1/contract/web/{CONTRACT_KEY}/{path}`, and that path is same-origin with the UI's own sandboxed iframe regardless of whose key it names — the gateway CSP is scoped per-node/per-browser-host, not per-contract. So a UI can embed e.g. `<audio src="/v1/contract/web/{ASSET_CONTRACT_KEY}/track.mp3">` referencing a *separate* contract instance without tripping `connect-src`/`default-src <iframe-origin>`. A contract used purely as an asset store doesn't need an `index.html`.

Added:
- New subsection in `ui-patterns.md` right after "Gateway CSP: Vendor Your Assets"
- Cross-reference from `state-authorization-patterns.md`'s existing "State Size Budget" section (framed as a special case of the same sharding advice, not a new problem)
- Pointer update in `SKILL.md`'s reference list
- Version bump 1.16.0 → 1.17.0 + CHANGELOG entry (required by `version-check.yml`)

## Testing
Docs-only change. Ran an independent adversarial review verifying every technical claim against the actual freenet-core source (`client_api.rs`, `path_handlers.rs`) and the hosting-invariants doc:
- CSP origin is derived from `Host`/`X-Forwarded-Host`, never the contract key — confirmed same-origin claim
- `variable_content`/`resolve_web_asset_path` serve any file under a contract's cache dir keyed only by its `ContractInstanceId`, no relation to "the" UI contract required, no index.html requirement
- No auth-token/session binding gates static asset GETs
- `Access-Control-Allow-Origin: *` confirmed present on these responses
- Demand-driven hosting claim matches invariant 3 (per-contract eviction ranking) without overstatement

No problems found in review.

[AI-assisted - Claude]