### PR TITLE
docs(dapp-builder): building on someone else's contract (v1.23.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.20.0"
+    "version": "1.23.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## 1.23.0 (2026-08-17)
 
+> Updated 2026-08-18: the pointer contract is now LIVE. River published the
+> first two records (`river.room-contract`, `river.chat-delegate`), both
+> verified from the network and resolved through `resolve_app_pointer`. Adoption
+> is still thin — Atlas and Delta have records prepared but unpublished, and
+> everything else including ghostkeys has none — so the bundle-fetch fallback in
+> `building-on-other-apps.md` remains the right path for those apps.
+
 The skill covered how to survive *your own* re-keys and said nothing about
 surviving *someone else's*, which is the problem third-party integrators
 actually have.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,15 @@ actually have.
   arms that carry a record, which silently no-ops on the other five), and states
   the scope boundary: the pointer solves **addressing only** and says nothing
   about whether state or secrets under the old key survived.
-- **The pointer contract is consumable, and the skill said it was not.**
-  `references/upgrade-and-migration.md` described it as "emerging, not yet
-  consumable" with "no client resolver exists yet". A resolver ships in
-  `freenet-migrate` 0.6.0 (`freenet_migrate::pointer`), so that text was out of
-  date; corrected, with the author-side and consumer-side halves cross-linked.
+- **The resolver is published, and the skill said no resolver existed.**
+  `references/upgrade-and-migration.md` described the pointer contract as
+  "emerging, not yet consumable" with "no client resolver exists yet". A
+  resolver ships in `freenet-migrate` 0.6.0 (`freenet_migrate::pointer`), so
+  that text was out of date; corrected, with the author-side and consumer-side
+  halves cross-linked. Note this is a claim about the *resolver*, not about
+  adoption: pointer adoption is thin, so the new file and the SKILL.md callout
+  both say to expect the webapp-bundle fallback to be the working path for most
+  apps today.
 - **`delegate-patterns.md` → "Depending on Someone Else's Delegate"** now offers
   the pointer as the principled mechanism alongside the existing webapp-bundle
   fetch, and is explicit about what the bundle pattern does not give you: no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.23.0 (2026-08-17)
+
+The skill covered how to survive *your own* re-keys and said nothing about
+surviving *someone else's*, which is the problem third-party integrators
+actually have.
+
+- **New `references/building-on-other-apps.md`** — the consumer side of
+  addressing. A backward probe searches backward from a key you already hold, so
+  it cannot help an integrator who is pinned to a key that has since moved;
+  neither can pinning a version of the author's crate, which pins you to their
+  view of the key as of their release. The answer is to resolve the author's
+  pointer at runtime. Covers the three things integrators get wrong (deriving
+  with the pointer's params instead of your own, not persisting the anti-rollback
+  floor — including after a withdrawal — and handling only the two `PointerOutcome`
+  arms that carry a record, which silently no-ops on the other five), and states
+  the scope boundary: the pointer solves **addressing only** and says nothing
+  about whether state or secrets under the old key survived.
+- **The pointer contract is consumable, and the skill said it was not.**
+  `references/upgrade-and-migration.md` described it as "emerging, not yet
+  consumable" with "no client resolver exists yet". A resolver ships in
+  `freenet-migrate` 0.6.0 (`freenet_migrate::pointer`), so that text was out of
+  date; corrected, with the author-side and consumer-side halves cross-linked.
+- **`delegate-patterns.md` → "Depending on Someone Else's Delegate"** now offers
+  the pointer as the principled mechanism alongside the existing webapp-bundle
+  fetch, and is explicit about what the bundle pattern does not give you: no
+  author signature over the answer, no rollback protection, no withdrawal signal.
+- **Skill description now names integration**, so the skill loads for "how do I
+  read another app's contract" and not only for building or upgrading your own.
+- **Version housekeeping:** `marketplace.json` was still at 1.20.0 while this
+  changelog had already published 1.21.0 and 1.22.0 — both landed directly on
+  main, and the version-bump workflow only triggers on `pull_request`, so it
+  never ran for them. Bumped straight to 1.23.0. The CI trigger gap is filed
+  separately; this entry only fixes the drift.
+
 ## 1.22.0 (2026-08-17)
 
 Canonical serialization was documented for summaries only, and the commutativity

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -129,7 +129,10 @@ Follow these phases in order.
 > failure is silent: every read comes back looking like "this user has nothing
 > stored". Pinning a version of their crate does not help — that pins you to
 > their view of the key as of their release, which is the thing that went stale.
-> Resolve their pointer at runtime instead. See
+> Fetch their key at runtime instead: resolve their author-signed pointer if
+> they publish one, and otherwise read it from their webapp bundle, which is
+> what ghostkeys does today. Pointer adoption is thin, so expect the fallback to
+> be the path for most apps right now. Either beats a compiled-in constant. See
 > `references/building-on-other-apps.md`.
 >
 > **Working on an app that already exists?** Before anything else, check whether

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dapp-builder
-description: Build and maintain decentralized applications on Freenet using river as a template. Guides through designing contracts (shared state), delegates (private state), and UI, and through upgrading a live dApp safely. Use when user wants to create a new Freenet dApp, design contract state, implement delegates, build a Freenet-connected UI, OR upgrade an existing dApp — bump freenet-stdlib, ship a new contract/delegate version (v2), fix a bug that re-keys the WASM, or migrate state across a contract/delegate key change without breaking invites or losing data.
+description: Build and maintain decentralized applications on Freenet using river as a template. Guides through designing contracts (shared state), delegates (private state), and UI, and through upgrading a live dApp safely. Use when user wants to create a new Freenet dApp, design contract state, implement delegates, build a Freenet-connected UI, OR upgrade an existing dApp — bump freenet-stdlib, ship a new contract/delegate version (v2), fix a bug that re-keys the WASM, or migrate state across a contract/delegate key change without breaking invites or losing data. Also use when INTEGRATING with a contract or delegate published by another app — reading another project's contract state, depending on a platform delegate, or deciding how to address someone else's artifact so it survives their re-keys.
 license: LGPL-3.0
 ---
 
@@ -122,6 +122,16 @@ Beyond that, make sure your state genuinely converges through `summarize` / `del
 
 Follow these phases in order.
 
+> **Building on an app you do NOT own** — reading River rooms, using the
+> ghostkeys delegate, indexing another project's contracts? Do not hardcode
+> their contract or delegate key. It is `BLAKE3(BLAKE3(wasm) ‖ params)`, so it
+> moves on every re-key of theirs, including a bare version bump, and the
+> failure is silent: every read comes back looking like "this user has nothing
+> stored". Pinning a version of their crate does not help — that pins you to
+> their view of the key as of their release, which is the thing that went stale.
+> Resolve their pointer at runtime instead. See
+> `references/building-on-other-apps.md`.
+>
 > **Working on an app that already exists?** Before anything else, check whether
 > it hardcodes a *delegate key* belonging to a platform delegate it does not own
 > (ghostkeys being the one in use today). That constant goes stale on every
@@ -325,6 +335,9 @@ References:
   contract/delegate upgrades: the five migration properties (idempotent,
   resumable, non-destructive, regression-gated, observable), enumerating
   dynamic key families, the upgrade test harness, and staged reversible rollout.
+- `references/building-on-other-apps.md` — the *consumer* side: integrating with
+  a contract or delegate you do not own, resolving the author's pointer instead
+  of pinning a key, the seven outcome arms, and what a pointer does not tell you.
 
 ## Project Structure Templates
 

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -6,12 +6,28 @@ project's contracts. Everything in `upgrade-and-migration.md` is written from
 the *author's* side. The two problems are different, and solving the author's
 one does not solve yours.
 
-> **Adoption is thin, so check before you build on it.** The pointer mechanism
-> below is new. Do not assume the app you depend on has published one — for most
-> apps today the honest answer is that they have not, and your resolve will
-> return `NeverPublished`. Resolve first, and keep the bundle-fetch fallback at
-> the end of this file for the apps that have not published yet. Both beat a
-> constant compiled into your build.
+> **Adoption is thin, so check before you build on it.** The mechanism works and
+> is live, but almost nothing publishes yet.
+>
+> | app | `app_id` | pointer key |
+> |---|---|---|
+> | River | `river.room-contract` | `Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az` |
+> | River | `river.chat-delegate` | `6qF2H5JRPBxbKC45UtPnzdDzyfsejYFW1UwDLGDU66mu` |
+>
+> That is the complete list as of 2026-08-18. River's author key is
+> `river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ`, published in
+> River's `FREENET.md` — **take it from there, not from here**, for the reason
+> given under "the author key is the whole trust anchor" below.
+>
+> Atlas and Delta have records prepared but not published. Everything else,
+> including ghostkeys, has none — so for those your resolve returns
+> `NeverPublished` (a real "not found") or `Unavailable` (your transport could
+> not tell), and the baked-in fallback is legitimately what you use.
+>
+> So: resolve first, and keep the bundle-fetch fallback at the end of this file
+> for the apps that have not published. Both beat a constant compiled into your
+> build, and the fallback stops being needed one app at a time rather than all
+> at once.
 
 ## The failure, stated once
 

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -1,0 +1,180 @@
+# Building on Someone Else's Contract or Delegate
+
+This file is the **consumer** side: you are integrating with an app you do not
+own — reading River rooms, using the ghostkeys delegate, indexing another
+project's contracts. Everything in `upgrade-and-migration.md` is written from
+the *author's* side. The two problems are different, and solving the author's
+one does not solve yours.
+
+## The failure, stated once
+
+A contract or delegate key is `BLAKE3(BLAKE3(wasm) ‖ params)`. It moves whenever
+the WASM moves — a feature, a dependency bump, a rustc upgrade, a version bump
+with no behaviour change at all. When the app you integrate with re-keys:
+
+- **Their** users' data migrates forward, if they did their job. Solved.
+- **Your** reference does not. It is a constant you compiled in. After the
+  re-key it addresses an empty namespace.
+
+The failure is silent and it lies to you. Every read comes back looking exactly
+like "this user has nothing stored" — not like an error — because at the
+protocol level those two are indistinguishable. Your error handling cannot help.
+
+This is not hypothetical. The ghostkeys delegate re-keyed twice in one day for
+release-hygiene reasons with no behaviour change; every integration broke, and
+the first anyone knew was a user reporting that their Ghost Key worked in the
+vault but not elsewhere — the integrating app had told them to go and buy one
+they already owned ([freenet/ghostkeys#21](https://github.com/freenet/ghostkeys/issues/21)).
+
+**A backward probe does not rescue you.** The legacy-code-hash registry in
+`upgrade-and-migration.md` searches *backward* from a current key, to recover
+state the author's own users left behind. As an integrator you have the opposite
+problem: you are pinned to a key that is now the *old* one, and there is nothing
+backward about the thing you need to find. Pinning a version of the author's
+crate does not help either — it pins you to *their* view of the key as of their
+release, which is precisely the thing that went stale.
+
+## The mechanism: an author-signed pointer
+
+A shared, frozen pointer WASM lives at a derivable address per
+`(author_vk, app_id)`. Its state is 100 bytes: an author-signed
+`{version, code_hash, signature}` naming the **current code hash** of some other
+contract or delegate. You resolve it at runtime and derive the key you actually
+wanted.
+
+Because the pointer WASM is frozen and its address is derived from the author's
+key plus a name, you need no prior reference to the thing you are addressing —
+which is what makes this work for a third party. The in-state `OptionalUpgrade`
+pointer in `contract-patterns.md` is a different thing: it is per-instance and
+only findable by a client that already holds a reference to *that* contract.
+
+Mechanics, wire format, and the operational requirements are in the contract's
+own README — do not restate them here, or the two copies drift:
+<https://github.com/freenet/freenet-migrate/blob/main/contracts/pointer-contract/README.md>
+
+## Resolving one
+
+```rust
+use freenet_migrate::pointer::{resolve_app_pointer, PointerFloor, PointerOutcome};
+
+let floor = load_floor_for(author_vk, b"river.room-contract")   // your storage
+    .unwrap_or_else(PointerFloor::never_resolved);
+
+let outcome = resolve_app_pointer(&mut io, &author_vk, b"river.room-contract", floor).await?;
+```
+
+In a browser UI, whose WebSocket handler is shared and has no awaitable
+request/response correlation, use `PointerResolver` — the same logic as a
+sans-IO driver you pump from your existing response handler — instead of the
+`async fn`.
+
+### Three things people get wrong
+
+**1. Derive with YOUR OWN params, never the pointer's.** The pointer tells you a
+*code hash*, not a key. The pointer's params identify the pointer; yours
+identify the instance you want — the room owner's key, your delegate's config,
+whatever it is for you.
+
+```rust
+let key = resolved.contract_id(&my_own_params);   // NOT the pointer's params
+let dk  = resolved.delegate_key(&my_own_params);
+```
+
+**2. Persist `outcome.next_floor()`, keyed by `(author_vk, app_id)`.** This is
+the anti-rollback floor. Store `version`, `code_hash` **and** `is_withdrawn`,
+and rebuild with `PointerFloor::at` / `PointerFloor::withdrawn_at` — do not
+infer withdrawal from a zeroed hash column. Persisting it after a **withdrawal**
+matters most: a withdrawal is a signed record at a version like any other, so if
+you stop resolving without recording its version, your floor stays at the
+pre-withdrawal value and any peer can serve a real, validly signed
+pre-withdrawal record that resurrects code the author explicitly withdrew.
+
+**3. Handle every arm.** `PointerOutcome` has seven variants and only two carry
+a record. The tempting shape
+
+```rust
+if let Some(r) = outcome.resolved() { use_it(r) }        // WRONG
+```
+
+silently no-ops on the other five, so a withdrawal, a rollback attempt and a
+plain timeout all collapse into "nothing happened".
+
+| Outcome | What it means | What to do |
+|---|---|---|
+| `Resolved` / `Unchanged` | verified record | derive your key from it |
+| `Withdrawn` | the author retired this artifact | stop. Do **not** fall back to a baked-in key |
+| `NeverPublished` | no pointer has ever resolved on this install | the **only** case where a baked-in key is legitimate |
+| `Stale` | a peer served a validly-signed record older than your floor, already refused | keep your last resolved key; retry. **Routine, not an attack signal** — a freshly bootstrapped or recently evicted node has no prior state to compare against, so it can transiently serve an older record |
+| `CompetingRecord` | two author-signed records exist at the same version | keep your last resolved key; do not pick between them. (There is a documented case where deriving from your own floor is legitimate, since the network's merge converges on the lower code hash and your floor already holds it — but it turns on your floor's *provenance*, so read the variant's docs before relying on it) |
+| `Unavailable` | nothing could be learned — timeout, failure, empty body, or a pointer reported absent that has resolved before | keep your last resolved key; retry. Silence is not absence, and an attacker who can briefly break reachability must not thereby win a downgrade |
+
+`outcome.may_use_baked_in_fallback()` encodes the fallback rule so you do not
+have to re-derive it; it is true for `NeverPublished` and nothing else.
+
+Note that "keep your last resolved key" is doing real work in four of those
+rows: the failure you are guarding against is an attacker who makes the pointer
+briefly unreachable, or replays an old record, and collects a downgrade from a
+client that treats either as "no pointer, use the built-in default".
+
+## What the pointer does NOT give you
+
+**It solves addressing only.** It tells you where the artifact is now. It says
+nothing about whether the state or secrets held under the previous key survived
+the move, and assuming they did produces a bug that looks like "this user has no
+data" rather than an error.
+
+Be concrete about it: a design review of River found (as of 2026-08) that
+delegate secrets written to its dedicated secure namespace do **not** survive a
+delegate re-key, while secrets written to its readable blob do, because the
+migration probe only reaches the latter — and River re-keys roughly weekly. So
+an integrator who resolves River's delegate pointer correctly, and then assumes
+the user's secrets came with it, will be wrong for every secret in that
+namespace. Resolving the pointer correctly is necessary for a safe upgrade and
+nowhere near sufficient.
+
+What you *do* get, and it is the thing that was missing in the ghostkeys
+incident, is the ability to tell **"the thing I was built against moved"** apart
+from **"this user has no data"**.
+
+## If the app you depend on has not published a pointer
+
+Ask them to. Until they do, the field-proven fallback is to fetch their current
+key at runtime from something whose address *is* stable — typically a file
+inside their webapp bundle, since a web container's id is derived from fixed
+WASM and fixed params, so publishing a new version changes its state and not its
+id. That pattern, its CSP/CORS behaviour inside a sandboxed webapp, and its
+three rules are in `delegate-patterns.md` → "Depending on Someone Else's
+Delegate".
+
+It works, and it needs no new infrastructure. What it does not give you is an
+author signature over the answer, an anti-rollback floor, or a way for the
+author to say "withdrawn" — which is the whole difference.
+
+## If you are the author
+
+Publishing a pointer is the courtesy that keeps your integrators alive across
+your own re-keys, and it costs one signed 100-byte record per release.
+
+- **`app_id` names the artifact, not its kind**: `<project>.<artifact>`, e.g.
+  `river.room-contract`, `river.chat-delegate`, `ghostkeys.ghostkey-delegate`.
+  Charset is lowercase `[a-z0-9._-]`, 1–64 bytes.
+- **The author key is a long-lived identity.** Keep it offline; it is not a
+  per-release key and there is deliberately no delegated signing.
+- **Gate `version` on a single committed monotonic counter**, the way a
+  web-container version counter works — never a wall-clock timestamp.
+- **PUT the committed, published WASM artifact; never a local rebuild.** A local
+  rebuild puts your pointer at an address nobody else derives: invisible to every
+  consumer, and indistinguishable from success on your side.
+- Publishing a pointer does not relieve you of the backward probe. They answer
+  different questions — the probe moves *your users' state* forward, the pointer
+  tells *other people* where you went.
+
+## Cross-references
+
+- `delegate-patterns.md` → "Depending on Someone Else's Delegate" — the
+  webapp-bundle fallback and how to read `DelegateError` on the client.
+- `upgrade-and-migration.md` — the author-side playbook, including the pointer
+  as a stable identity anchor.
+- `contract-patterns.md` — the in-state `OptionalUpgrade` pointer, which is a
+  different mechanism for a different reader.
+- freenet-core#2776 — live adoption status.

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -6,6 +6,13 @@ project's contracts. Everything in `upgrade-and-migration.md` is written from
 the *author's* side. The two problems are different, and solving the author's
 one does not solve yours.
 
+> **Adoption is thin, so check before you build on it.** The pointer mechanism
+> below is new. Do not assume the app you depend on has published one — for most
+> apps today the honest answer is that they have not, and your resolve will
+> return `NeverPublished`. Resolve first, and keep the bundle-fetch fallback at
+> the end of this file for the apps that have not published yet. Both beat a
+> constant compiled into your build.
+
 ## The failure, stated once
 
 A contract or delegate key is `BLAKE3(BLAKE3(wasm) ‖ params)`. It moves whenever
@@ -36,7 +43,7 @@ release, which is precisely the thing that went stale.
 
 ## The mechanism: an author-signed pointer
 
-A shared, frozen pointer WASM lives at a derivable address per
+A shared, frozen pointer WASM is addressed at a derivable address per
 `(author_vk, app_id)`. Its state is 100 bytes: an author-signed
 `{version, code_hash, signature}` naming the **current code hash** of some other
 contract or delegate. You resolve it at runtime and derive the key you actually
@@ -46,7 +53,9 @@ Because the pointer WASM is frozen and its address is derived from the author's
 key plus a name, you need no prior reference to the thing you are addressing —
 which is what makes this work for a third party. The in-state `OptionalUpgrade`
 pointer in `contract-patterns.md` is a different thing: it is per-instance and
-only findable by a client that already holds a reference to *that* contract.
+only findable by a client that already holds a reference to *that* contract. The
+`FacadePointer` in `facade-pattern.md` is a third thing again: it moves an
+audience to a different contract, for the author's own users.
 
 Mechanics, wire format, and the operational requirements are in the contract's
 own README — do not restate them here, or the two copies drift:
@@ -57,39 +66,78 @@ own README — do not restate them here, or the two copies drift:
 ```rust
 use freenet_migrate::pointer::{resolve_app_pointer, PointerFloor, PointerOutcome};
 
-let floor = load_floor_for(author_vk, b"river.room-contract")   // your storage
-    .unwrap_or_else(PointerFloor::never_resolved);
+// AUTHOR_VK is a build-time constant from the app's FREENET.md. See below.
+let floor = match load_stored_floor(AUTHOR_VK, b"river.room-contract") {
+    Ok(Some(f)) => f,                       // a floor we previously persisted
+    Ok(None)    => seeded_floor(),          // no row yet -> seed, see trap 3
+    Err(e)      => return Err(e),           // stored but unreadable -> SURFACE IT
+};
 
-let outcome = resolve_app_pointer(&mut io, &author_vk, b"river.room-contract", floor).await?;
+let outcome = resolve_app_pointer(&mut io, &AUTHOR_VK, b"river.room-contract", floor).await?;
 ```
 
 In a browser UI, whose WebSocket handler is shared and has no awaitable
 request/response correlation, use `PointerResolver` — the same logic as a
 sans-IO driver you pump from your existing response handler — instead of the
-`async fn`.
+`async fn`. Do not run two concurrent resolutions for the same
+`(author_vk, app_id)` on a shared handler.
 
-### Three things people get wrong
+**Re-resolve periodically and on every reconnect.** A single resolve at startup
+leaves you pinned for the life of the session, and repeated resolving is the
+only thing that bounds how long an author's newer record can be suppressed from
+you. Subscribing to the pointer is a best-effort accelerant, not a substitute:
+subscriptions are dropped silently across reconnects.
 
-**1. Derive with YOUR OWN params, never the pointer's.** The pointer tells you a
+### Four things people get wrong
+
+**1. `author_vk` is the entire trust anchor.** It must be a build-time constant,
+taken from the app's `FREENET.md` — never fetched from the network, or you have
+simply moved the problem. Note that nothing binds a key to a name: a
+typosquatter can publish a validly-signed pointer under a plausible `app_id`, so
+a correct signature proves the record came from *that key*, not that the key is
+who you think it is.
+
+**2. Derive with YOUR OWN params, never the pointer's.** The pointer tells you a
 *code hash*, not a key. The pointer's params identify the pointer; yours
 identify the instance you want — the room owner's key, your delegate's config,
 whatever it is for you.
 
 ```rust
-let key = resolved.contract_id(&my_own_params);   // NOT the pointer's params
-let dk  = resolved.delegate_key(&my_own_params);
+let id = resolved.contract_id(&my_own_params);   // NOT the pointer's params
+let dk = resolved.delegate_key(&my_own_params);
 ```
 
-**2. Persist `outcome.next_floor()`, keyed by `(author_vk, app_id)`.** This is
-the anti-rollback floor. Store `version`, `code_hash` **and** `is_withdrawn`,
-and rebuild with `PointerFloor::at` / `PointerFloor::withdrawn_at` — do not
-infer withdrawal from a zeroed hash column. Persisting it after a **withdrawal**
-matters most: a withdrawal is a signed record at a version like any other, so if
-you stop resolving without recording its version, your floor stays at the
-pre-withdrawal value and any peer can serve a real, validly signed
-pre-withdrawal record that resurrects code the author explicitly withdrew.
+`contract_id` returns a `ContractInstanceId`, which is what GET and SUBSCRIBE
+take. An UPDATE currently needs a full `ContractKey`, so do not store the
+instance id and assume it is enough for every operation
+([freenet-core#4978](https://github.com/freenet/freenet-core/issues/4978)).
 
-**3. Handle every arm.** `PointerOutcome` has seven variants and only two carry
+**3. Persist `outcome.next_floor()`, keyed by `(author_vk, app_id)` — and seed
+the first one.** This is the anti-rollback floor. Store `version`, `code_hash`
+**and** `is_withdrawn`, and rebuild with `PointerFloor::at` /
+`PointerFloor::withdrawn_at`; do not infer withdrawal from a zeroed hash column.
+
+Two failure shapes here, both easy to write by accident:
+
+- *Starting at `never_resolved` when you know better.* A first resolve has
+  nothing to compare against, so it adopts any validly-signed record a peer
+  serves, including a genuine but superseded one. If you ship knowing the app's
+  current version and code hash, seed the first floor from those constants with
+  `PointerFloor::at`.
+- *Recovering from a corrupt floor with
+  `unwrap_or_else(|_| PointerFloor::never_resolved())`.* This is the first thing
+  to reach for and the crate explicitly forbids it: it converts a corrupt floor
+  into "first run", which is the one state that unlocks the baked-in fallback.
+  An absent row is legitimately `never_resolved`; a stored floor that fails to
+  rebuild is untrustworthy and must surface.
+
+Persisting after a **withdrawal** matters most: a withdrawal is a signed record
+at a version like any other, so if you stop resolving without recording its
+version, your floor stays at the pre-withdrawal value and any peer can serve a
+real, validly signed pre-withdrawal record that resurrects code the author
+explicitly withdrew.
+
+**4. Handle every arm.** `PointerOutcome` has seven variants and only two carry
 a record. The tempting shape
 
 ```rust
@@ -102,19 +150,43 @@ plain timeout all collapse into "nothing happened".
 | Outcome | What it means | What to do |
 |---|---|---|
 | `Resolved` / `Unchanged` | verified record | derive your key from it |
-| `Withdrawn` | the author retired this artifact | stop. Do **not** fall back to a baked-in key |
-| `NeverPublished` | no pointer has ever resolved on this install | the **only** case where a baked-in key is legitimate |
+| `Withdrawn` | the author retired this artifact | persist the floor **first**, then stop. Do **not** fall back to a baked-in key: the author is saying there is no current code, not that the old code is current again |
+| `NeverPublished` | the network answered definitively that no pointer has ever been published here, and none has ever resolved on this install | the **only** case where a baked-in key is legitimate |
 | `Stale` | a peer served a validly-signed record older than your floor, already refused | keep your last resolved key; retry. **Routine, not an attack signal** — a freshly bootstrapped or recently evicted node has no prior state to compare against, so it can transiently serve an older record |
 | `CompetingRecord` | two author-signed records exist at the same version | keep your last resolved key; do not pick between them. (There is a documented case where deriving from your own floor is legitimate, since the network's merge converges on the lower code hash and your floor already holds it — but it turns on your floor's *provenance*, so read the variant's docs before relying on it) |
 | `Unavailable` | nothing could be learned — timeout, failure, empty body, or a pointer reported absent that has resolved before | keep your last resolved key; retry. Silence is not absence, and an attacker who can briefly break reachability must not thereby win a downgrade |
 
+> **If your floor is a withdrawal, "keep your last resolved key" never applies.**
+> A tombstone sorts below every real code hash, so once you hold a withdrawal
+> floor, a genuine pre-withdrawal record replayed at that version loses the
+> tiebreak and surfaces as `CompetingRecord` (or as `Stale`, one version down).
+> Following the table literally there resumes the retired code out of your own
+> memory — the same resurrection the withdrawal floor exists to prevent, reached
+> from the other side. Check `floor.is_withdrawn()` on both rows and stay
+> stopped, exactly as for `Withdrawn`.
+
 `outcome.may_use_baked_in_fallback()` encodes the fallback rule so you do not
 have to re-derive it; it is true for `NeverPublished` and nothing else.
 
-Note that "keep your last resolved key" is doing real work in four of those
-rows: the failure you are guarding against is an attacker who makes the pointer
-briefly unreachable, or replays an old record, and collects a downgrade from a
-client that treats either as "no pointer, use the built-in default".
+"Keep your last resolved key" is doing real work in those rows: the failure you
+are guarding against is an attacker who makes the pointer briefly unreachable,
+or replays an old record, and collects a downgrade from a client that treats
+either as "no pointer, use the built-in default".
+
+`PointerOutcome` is `#[non_exhaustive]`, so match with a `_ =>` arm rather than
+exhaustively — and route that arm to keep-your-key-and-retry, which is the safe
+default for anything added later.
+
+**Errors are not a fallback trigger either.** `resolve_app_pointer` returns
+`Err` for transport failures and malformed responses. Both are retryable and
+neither permits the baked-in key: answering a single GET with 99 bytes is the
+cheapest hostile move available, so a client that treats `Err` as "no pointer"
+undoes the whole outcome table.
+
+**A resolved pointer you cannot fetch is normal.** The record can verify while
+the code it names is momentarily unfetchable. Retry with backoff, keep the
+derived key, and report "the current version could not be fetched" — never "this
+user has no data".
 
 ## What the pointer does NOT give you
 
@@ -138,17 +210,17 @@ from **"this user has no data"**.
 
 ## If the app you depend on has not published a pointer
 
-Ask them to. Until they do, the field-proven fallback is to fetch their current
-key at runtime from something whose address *is* stable — typically a file
-inside their webapp bundle, since a web container's id is derived from fixed
-WASM and fixed params, so publishing a new version changes its state and not its
-id. That pattern, its CSP/CORS behaviour inside a sandboxed webapp, and its
-three rules are in `delegate-patterns.md` → "Depending on Someone Else's
-Delegate".
+Today that is the common case, so expect to need this. Ask them to publish one.
+Until they do, the field-proven fallback is to fetch their current key at
+runtime from something whose address *is* stable — typically a file inside their
+webapp bundle, since a web container's id is derived from fixed WASM and fixed
+params, so publishing a new version changes its state and not its id. That
+pattern, its CSP/CORS behaviour inside a sandboxed webapp, and its three rules
+are in `delegate-patterns.md` → "Depending on Someone Else's Delegate".
 
-It works, and it needs no new infrastructure. What it does not give you is an
-author signature over the answer, an anti-rollback floor, or a way for the
-author to say "withdrawn" — which is the whole difference.
+It works, and it needs no new infrastructure. What it does not give you is
+anything *your* code verifies: no signature you check client-side, no
+anti-rollback floor, and no way for the author to say "withdrawn".
 
 ## If you are the author
 
@@ -158,6 +230,8 @@ your own re-keys, and it costs one signed 100-byte record per release.
 - **`app_id` names the artifact, not its kind**: `<project>.<artifact>`, e.g.
   `river.room-contract`, `river.chat-delegate`, `ghostkeys.ghostkey-delegate`.
   Charset is lowercase `[a-z0-9._-]`, 1–64 bytes.
+- **Publish your `author_vk` in your `FREENET.md`.** It is your integrators'
+  trust anchor and they are told to take it from there.
 - **The author key is a long-lived identity.** Keep it offline; it is not a
   per-release key and there is deliberately no delegated signing.
 - **Gate `version` on a single committed monotonic counter**, the way a
@@ -175,6 +249,8 @@ your own re-keys, and it costs one signed 100-byte record per release.
   webapp-bundle fallback and how to read `DelegateError` on the client.
 - `upgrade-and-migration.md` — the author-side playbook, including the pointer
   as a stable identity anchor.
-- `contract-patterns.md` — the in-state `OptionalUpgrade` pointer, which is a
-  different mechanism for a different reader.
+- `contract-patterns.md` — the in-state `OptionalUpgrade` pointer, a different
+  mechanism for a different reader.
+- `facade-pattern.md` — the `FacadePointer`, a third mechanism again, for moving
+  your own audience to a different contract.
 - freenet-core#2776 — live adoption status.

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -409,8 +409,23 @@ go and buy one they already owned
 ### What to do instead
 
 **Fetch the current key at runtime from something whose address is stable.**
+Two ways, and they are not exclusive:
 
-The pattern ghostkeys uses, and a good default: the project publishes its
+**If the project publishes a pointer, resolve it.** An author-signed pointer
+record at `(author_vk, app_id)` names the artifact's current code hash, and
+`freenet-migrate` 0.6.0 ships the resolver. You get an author signature over the
+answer, an anti-rollback floor, and an explicit "withdrawn" state — none of
+which the bundle-file pattern below can give you. See
+`building-on-other-apps.md`, which also covers the three things integrators get
+wrong (deriving with the pointer's params instead of your own, not persisting
+the floor, and handling only the two outcome arms that carry a record).
+
+**Otherwise, fetch it from the project's webapp bundle.** This needs no
+cooperation beyond the project publishing the file, works today, and is what
+ghostkeys does. Note that it addresses the same problem with less: no signature
+over the answer, no rollback protection, no withdrawal signal.
+
+The pattern ghostkeys uses, and a good default where no pointer exists: the project publishes its
 current delegate key as a file inside its own **webapp bundle**, and you fetch
 it. A webapp contract's id is derived from the web container WASM and its
 parameters — both fixed — so publishing a new version updates the contract's

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -421,9 +421,13 @@ wrong (deriving with the pointer's params instead of your own, not persisting
 the floor, and handling only the two outcome arms that carry a record).
 
 **Otherwise, fetch it from the project's webapp bundle.** This needs no
-cooperation beyond the project publishing the file, works today, and is what
-ghostkeys does. Note that it addresses the same problem with less: no signature
-over the answer, no rollback protection, no withdrawal signal.
+cooperation beyond the project publishing the file, works today, is what
+ghostkeys does, and is the path for most apps right now since pointer adoption
+is thin. Note that it addresses the same problem with less. The bundle is
+owner-signed, versioned contract state at the node layer, so this is not "an
+unsigned answer" — but nothing in it is verified by *your* code: you get no
+signature you check client-side, no anti-rollback floor, and no way for the
+author to say "withdrawn".
 
 The pattern ghostkeys uses, and a good default where no pointer exists: the project publishes its
 current delegate key as a file inside its own **webapp bundle**, and you fetch

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -48,23 +48,31 @@ The whole procedure, start to finish:
    - an **index/registry contract** mapping a stable name → the current contract
      key — a level of indirection. (The index contract itself needs this same
      treatment: its own address must be reachable via a stable anchor.)
-   - an **ecosystem-standard pointer contract** (emerging, not yet consumable) —
-     a shared, frozen "pointer" WASM at a derivable address `(author_vk,
-     app_id)`, whose state is an author-signed `{version, code_hash, sig}`
-     naming the current code hash of *some other* contract or delegate. The
-     record format is settled (freenet-core#5194; governance questions — author-key
-     rotation and recovery, whether adoption is mandatory — are still open), and
-     the contract is merged as an in-repo crate (freenet-migrate#9, deliberately
-     unpublished; the frozen, CI-hash-checked WASM artifact is the deliverable).
-     But **no client resolver exists yet** — as of this writing it is
-     unconsumed scaffolding, not an
-     adoptable mechanism, and it solves *addressing only* (it says nothing
-     about whether state or secrets held under the old key survived). It is
-     also a different thing from the in-state `OptionalUpgrade` pointer in
-     `contract-patterns.md`, which is per-instance and only findable by
-     clients that already hold a reference to *that* contract; the pointer
-     contract is for a third party with no prior reference at all. Check
-     freenet-core#2776 for current status before building on it.
+   - an **ecosystem-standard pointer contract** — a shared, frozen "pointer"
+     WASM at a derivable address `(author_vk, app_id)`, whose state is an
+     author-signed `{version, code_hash, sig}` naming the current code hash of
+     *some other* contract or delegate. The record format is settled
+     (freenet-core#5194; governance questions — author-key rotation and
+     recovery, whether adoption is mandatory — are still open), and the contract
+     is merged as an in-repo crate (freenet-migrate#9, deliberately unpublished
+     *as a crate*; the frozen, CI-hash-checked WASM artifact is the
+     deliverable). A client resolver ships in `freenet-migrate` 0.6.0
+     (`freenet_migrate::pointer`), so this is now consumable rather than
+     scaffolding — earlier revisions of this file said no resolver existed, and
+     that is out of date.
+
+     Two things to keep straight. It solves **addressing only**: it says nothing
+     about whether state or secrets held under the old key survived, and
+     assuming they did produces a bug shaped like "this user has no data". And
+     it is a different mechanism from the in-state `OptionalUpgrade` pointer in
+     `contract-patterns.md`, which is per-instance and only findable by clients
+     that already hold a reference to *that* contract; the pointer contract is
+     for a third party with no prior reference at all.
+
+     Publishing one is the author-side half. The consumer-side half — resolving
+     a pointer for an app you do **not** own, and the three things integrators
+     get wrong — is `building-on-other-apps.md`. Check freenet-core#2776 for
+     live adoption status.
 
    If v1 exposed a raw contract key as an identifier, fix *that* first — an upgrade
    cannot rescue an identifier that moves with the WASM. See

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -57,9 +57,10 @@ The whole procedure, start to finish:
      is merged as an in-repo crate (freenet-migrate#9, deliberately unpublished
      *as a crate*; the frozen, CI-hash-checked WASM artifact is the
      deliverable). A client resolver ships in `freenet-migrate` 0.6.0
-     (`freenet_migrate::pointer`), so this is now consumable rather than
-     scaffolding — earlier revisions of this file said no resolver existed, and
-     that is out of date.
+     (`freenet_migrate::pointer`) — earlier revisions of this file said no
+     resolver existed, and that is out of date. Adoption is a separate question
+     from availability, and it is thin: publishing a pointer is worth doing for
+     your integrators, but do not assume the apps *you* depend on have one.
 
      Two things to keep straight. It solves **addressing only**: it says nothing
      about whether state or secrets held under the old key survived, and


### PR DESCRIPTION
## Problem

The skill teaches an app how to survive **its own** re-keys. It says nothing
about surviving **someone else's**, which is the problem a third-party
integrator actually has — and it is the problem that turns into dependency hell
as more apps start building on each other's contracts.

Two things that look like they should help, and do not:

- **A backward probe does not help an integrator.** The legacy-code-hash
  registry searches *backward* from a key you already hold, to recover state the
  author's own users left behind. An integrator has the opposite problem: they
  are pinned to a key that has since moved, and there is nothing backward about
  the thing they need to find.
- **Pinning a version of the author's crate does not help.** It pins you to
  *their* view of the key as of *their* release, which is exactly the thing that
  went stale.

The failure is silent and it lies: every read comes back looking like "this user
has nothing stored", because at the protocol level that is indistinguishable
from "the key you named is empty now". This is not hypothetical — it is
[freenet/ghostkeys#21](https://github.com/freenet/ghostkeys/issues/21), where an
integrating app told a user to go and buy a Ghost Key they already owned.

## Approach

Document the consumer side, and correct a claim that has gone out of date.

- **New `references/building-on-other-apps.md`.** Resolve the author's pointer
  at runtime. Covers the three things integrators get wrong:
  1. deriving with the pointer's params instead of your own (the pointer names a
     *code hash*, not a key);
  2. not persisting `outcome.next_floor()` — including **after a withdrawal**,
     where failing to record the version lets any peer replay a validly signed
     pre-withdrawal record and resurrect code the author explicitly withdrew;
  3. writing `if let Some(r) = outcome.resolved()`, which silently no-ops on
     five of the seven `PointerOutcome` arms, so a withdrawal, a rollback attempt
     and a plain timeout all collapse into "nothing happened".

  It also states the scope boundary plainly: **the pointer solves addressing
  only.** It says nothing about whether state or secrets under the old key
  survived, and assuming they did produces a bug shaped like "this user has no
  data" rather than an error.

- **`upgrade-and-migration.md` was out of date.** It described the pointer
  contract as "emerging, not yet consumable" with "**no client resolver exists
  yet**". A resolver ships in `freenet-migrate` 0.6.0
  (`freenet_migrate::pointer`, from freenet-migrate#10). Corrected, and the
  author-side and consumer-side halves are now cross-linked rather than one
  file trying to carry both.

- **`delegate-patterns.md` → "Depending on Someone Else's Delegate"** now offers
  the pointer as the principled mechanism *alongside* the existing
  webapp-bundle fetch rather than replacing it. The bundle pattern works today,
  needs no cooperation beyond publishing a file, and is what ghostkeys does — so
  it stays. What it cannot give you is stated explicitly: no author signature
  over the answer, no anti-rollback floor, no withdrawal signal.

- **Skill description names integration**, so the skill loads for "how do I read
  another app's contract" and not only for building or upgrading your own.

Mechanics and wire format are deliberately **not** restated here; they live in
the contract's own README and would drift if copied.

## Version housekeeping (please sanity-check)

`marketplace.json` was still at `1.20.0` while `CHANGELOG.md` had already
published `1.21.0` and `1.22.0`. Both of those landed **directly on main**, and
`.github/workflows/version-check.yml` triggers on `pull_request` only, so it
never ran for either. Net effect: three changelog versions shipped under one
plugin version number.

This PR bumps straight to `1.23.0`. It does **not** touch the workflow — a CI
trigger change is a different risk surface from a docs change and deserves its
own review. Filed separately.

## Testing

Documentation only; no code paths change. Claims were verified rather than
carried over:

- `freenet-migrate 0.6.0` / `freenet-migrate-build 0.2.0` confirmed via
  `cargo search`.
- The seven `PointerOutcome` variants, `may_use_baked_in_fallback()` being true
  for `NeverPublished` alone, and `next_floor()` returning `Some` for
  `Withdrawn`, all read off `freenet-migrate/src/pointer.rs` rather than from
  memory.
- The pointer contract's README URL was checked to resolve on a public repo.

One caveat for the reviewer: this PR describes the pointer as consumable. The
resolver is published, but **the pointer contract is not yet on the network**,
so no author has published a record for anyone to resolve. It should merge after
that happens, not before.

[AI-assisted - Claude]
