### PR TITLE
docs(dapp-builder): five pointer records live, not two (v1.24.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.23.0"
+    "version": "1.24.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.24.0 (2026-08-19)
+## 1.24.0 (2026-08-18)
 
 Pointer adoption went from two records to five, so the adoption table in
 `building-on-other-apps.md` was stale within a day of being written. That table
@@ -35,7 +35,7 @@ it states which apps an integrator can rely on resolving *today*.
 > everything else including ghostkeys has none — so the bundle-fetch fallback in
 > `building-on-other-apps.md` remains the right path for those apps.
 >
-> **Superseded by 1.24.0 (2026-08-19):** Atlas and Delta have since published.
+> **Superseded by 1.24.0 (later on 2026-08-18):** Atlas and Delta have since published.
 > The adoption note above is kept as it stood on the 18th; the current list is
 > the table in `building-on-other-apps.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.24.0 (2026-08-19)
+
+Pointer adoption went from two records to five, so the adoption table in
+`building-on-other-apps.md` was stale within a day of being written. That table
+is the one thing in this skill that goes wrong purely by the passage of time —
+it states which apps an integrator can rely on resolving *today*.
+
+- **Atlas and Delta have published.** The table now lists all five live records:
+  River's two, Atlas's `atlas.index-contract`, and Delta's `site-contract` and
+  `site-delegate`. All five were verified by resolving them from the live
+  network, not by reading the repos that generated them.
+- **Author keys are deliberately not listed here.** The table carries pointer
+  *addresses* only, which are public routing information, and sends the reader
+  to each app's own `FREENET.md` for the verifying key. Reading a trust anchor
+  out of a third-party table is the exact mistake the surrounding section warns
+  against, and listing them here invited it.
+- **Noted that the author-key encodings differ** — River's and Delta's are
+  `river:v1:vk:`-prefixed base58, Atlas's is bare hex, and both decode to the
+  same 32 raw bytes. An integrator who writes one parser and assumes will fail
+  on the second app they try.
+- **Called out that ghostkeys still has no record.** It is the app whose re-keys
+  motivated this file, so a reader is most likely to reach for a pointer exactly
+  where one does not yet exist; that reader needs the bundle-fetch fallback.
+
 ## 1.23.0 (2026-08-17)
 
 > Updated 2026-08-18: the pointer contract is now LIVE. River published the
@@ -10,6 +34,10 @@ All notable changes to this project will be documented in this file.
 > is still thin — Atlas and Delta have records prepared but unpublished, and
 > everything else including ghostkeys has none — so the bundle-fetch fallback in
 > `building-on-other-apps.md` remains the right path for those apps.
+>
+> **Superseded by 1.24.0 (2026-08-19):** Atlas and Delta have since published.
+> The adoption note above is kept as it stood on the 18th; the current list is
+> the table in `building-on-other-apps.md`.
 
 The skill covered how to survive *your own* re-keys and said nothing about
 surviving *someone else's*, which is the problem third-party integrators

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -7,22 +7,36 @@ the *author's* side. The two problems are different, and solving the author's
 one does not solve yours.
 
 > **Adoption is thin, so check before you build on it.** The mechanism works and
-> is live, but almost nothing publishes yet.
+> is live, but most apps still publish nothing.
 >
 > | app | `app_id` | pointer key |
 > |---|---|---|
 > | River | `river.room-contract` | `Ai4VLoC2jGdhpcB2UU8VPo3efUoxjm1Ju9VKXqRC63Az` |
 > | River | `river.chat-delegate` | `6qF2H5JRPBxbKC45UtPnzdDzyfsejYFW1UwDLGDU66mu` |
+> | Atlas | `atlas.index-contract` | `BwsKx5iDhjBJGDNAPtZbbC9f6twDAUrnb2Yh1D6Wng2K` |
+> | Delta | `delta.site-contract` | `6a8ZBaFft9wVFd1mAWVRRZepXXrnQNzRCD5tqM71hBm5` |
+> | Delta | `delta.site-delegate` | `ES2hnErmSh9Aip4862ZDKQCNvMeryfhj6b7FfpP5qmyZ` |
 >
-> That is the complete list as of 2026-08-18. River's author key is
-> `river:v1:vk:9Ebskq4y7NvJpTQTrF1FAxU8g6bR4Rhe4TRikXba55EJ`, published in
-> River's `FREENET.md` — **take it from there, not from here**, for the reason
-> given under "the author key is the whole trust anchor" below.
+> That is the complete list as of 2026-08-19, and all five resolve on the live
+> network today. Each app's author verifying key is published in **that app's
+> own `FREENET.md`** — River's, Atlas's, Delta's — and you should **take it from
+> there, not from this table**, for the reason given under "the author key is
+> the whole trust anchor" below. This file deliberately lists only the pointer
+> *addresses*, which are public routing information; the author key is the thing
+> an attacker would want you to read from the wrong place.
 >
-> Atlas and Delta have records prepared but not published. Everything else,
-> including ghostkeys, has none — so for those your resolve returns
-> `NeverPublished` (a real "not found") or `Unavailable` (your transport could
-> not tell), and the baked-in fallback is legitimately what you use.
+> **The author keys are not all encoded the same way**, which will bite you if
+> you write one parser and assume. River's and Delta's are `river:v1:vk:`-prefixed
+> base58 (Delta reuses River's `web-container-tool` encoding; the prefix says
+> nothing about ownership). Atlas's is bare hex. Both encodings decode to the
+> same 32 raw bytes, and it is those 32 bytes the resolver wants.
+>
+> Everything else, including ghostkeys, has no record — so for those your
+> resolve returns `NeverPublished` (a real "not found") or `Unavailable` (your
+> transport could not tell), and the baked-in fallback is legitimately what you
+> use. Worth noticing that ghostkeys — the app whose re-keys caused the breakage
+> this file exists to prevent — is still in that group, so the reader most likely
+> to reach for a pointer is the one it cannot yet help.
 >
 > So: resolve first, and keep the bundle-fetch fallback at the end of this file
 > for the apps that have not published. Both beat a constant compiled into your

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -17,7 +17,7 @@ one does not solve yours.
 > | Delta | `delta.site-contract` | `6a8ZBaFft9wVFd1mAWVRRZepXXrnQNzRCD5tqM71hBm5` |
 > | Delta | `delta.site-delegate` | `ES2hnErmSh9Aip4862ZDKQCNvMeryfhj6b7FfpP5qmyZ` |
 >
-> That is the complete list as of 2026-08-19, and all five resolve on the live
+> That is the complete list as of 2026-08-18, and all five resolve on the live
 > network today. Each app's author verifying key is published in **that app's
 > own `FREENET.md`** — River's, Atlas's, Delta's — and you should **take it from
 > there, not from this table**, for the reason given under "the author key is


### PR DESCRIPTION
## Problem

`building-on-other-apps.md` carries an adoption table telling integrators which apps they can rely on resolving a pointer for. It listed two records. There are now five: Atlas and Delta published after that file merged, so the skill was telling readers to use the bundle-fetch fallback for two apps that no longer need it.

That table is the one thing in this skill that goes wrong purely by the passage of time. It is a statement about the state of the network, not about how the mechanism works.

## Approach

All five entries were verified by **resolving them from the live network** through `resolve_app_pointer`, not by reading the repos that generated them — the repo is what the table would be derived from, so deriving from it would prove only self-consistency.

Three other things while in there, each fixing something the previous version got wrong rather than merely out of date:

- **Stopped listing author verifying keys.** The table now carries pointer *addresses* only and sends the reader to each app's own `FREENET.md` for the key. Addresses are public routing information; a verifying key is a trust anchor, and the section immediately below the table already warns against taking one from the wrong place. Listing them invited exactly that.
- **Noted the encodings differ.** River's and Delta's author keys are `river:v1:vk:`-prefixed base58; Atlas's is bare hex. Both decode to the same 32 raw bytes. An integrator who writes one parser against the first app they try will fail on the second, and nothing previously said so.
- **Called out that ghostkeys still has no record.** Ghostkeys' re-keys are the incident this file exists to prevent, so a reader is most likely to reach for a pointer exactly where one does not yet exist. That reader needs to be sent to the fallback deliberately, not left to discover `NeverPublished`.

## Testing

Docs only. The five records were each resolved from the live network before being listed; `marketplace.json` re-parsed as valid JSON after the version bump.

[AI-assisted - Claude]