### PR TITLE
docs(dapp-builder): writer-seam constraints, two build facts, three review questions (v1.26.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.25.0"
+    "version": "1.26.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.26.0 (2026-08-19)
+
+Three gaps freenet-core#2776 lists as outstanding for this skill.
+
+**The `freenet-migrate` writer seam** (`delegate-patterns.md`). The crate decides
+what to migrate; the app supplies the write, and four constraints on that write
+are invisible to the crate. Never-clobber is the app's choice and
+`UnionAllGenerations` rests entirely on it, so an overwriting writer installs the
+*oldest* generation's value with a clean report. An aggregate secret is
+read-merge-write, where skipping hides entries and overwriting deletes them.
+Markers must be durable when `record_marker` returns, since the crate never
+flushes one. And the cross-generation policy is a deliberate choice with a cost
+either way, not a default to leave alone.
+
+**Two operational facts** (`build-system.md`). Build-caching bugs cannot be
+reproduced in a git worktree: `.git` is a file there, so a `build.rs` naming
+`../.git/HEAD` in `cargo:rerun-if-changed` makes the script always-dirty, which
+is why Delta's stale-table bug survived investigation. `cargo:` directives are
+also parsed from stdout only, so `eprintln!("cargo:warning=...")` renders nothing
+and a `cargo:warning` is never a gate. Separately, a publish gate must be wired
+into the publish task itself: ghostkeys' author-key check lived only in CI while
+the publish path depended on a different script.
+
+**Three review questions** (`upgrade-and-migration.md`). Does the guard at a seam
+check both sides of it? Is the test double above or below the bug you care about?
+Is the operation idempotent with respect to the UI as well as to stored data?
+The last one is Delta's editor bug, where a storage-idempotent no-op merge still
+wiped the user's unsaved typing.
+
 ## 1.25.0 (2026-08-18)
 
 Summary SIZE guidance, alongside the determinism guidance that was already here.

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -744,6 +744,26 @@ fn main() {
 }
 ```
 
+### Build-caching bugs are invisible from a git worktree
+
+**Reproduce any stale-artifact or build-caching bug in a real clone, never in a
+worktree.** In a worktree `.git` is a *file*, not a directory, so a `build.rs`
+line like `println!("cargo:rerun-if-changed=../.git/HEAD")` names a path that
+cannot resolve, and cargo treats an unresolvable `rerun-if-changed` as
+always-dirty. The build script then re-runs on every build and never caches,
+which is precisely the condition under which a stale-artifact bug cannot appear.
+Delta's stale legacy-delegate table (freenet/delta#52, #53) survived
+investigation for exactly this reason: every reproduction attempt happened in a
+worktree, while `cargo make publish-delta` runs in a real clone. The fix is to
+resolve git metadata paths with `git rev-parse --git-path <spec>` instead of
+hardcoding `../.git/...` (freenet/delta#58).
+
+**Related, and worth knowing in the same breath: `cargo:` directives are parsed
+from stdout only.** `eprintln!("cargo:warning=...")` renders nothing at all, so a
+build script that "warns" on stderr and continues is silent rather than loud. And
+a `cargo:warning` is not a gate even on stdout, because nothing fails on it: when
+a build script finds a condition that must stop the build, `panic!`.
+
 ## Testing with Local Mode
 
 Freenet's **local mode** runs a standalone executor without network connectivity. Use this for testing contract and delegate logic during development.
@@ -866,6 +886,18 @@ dependencies = ["build-tailwind", "preflight"]
 ```
 
 The `check-migration` task verifies that committed WASM files match what's built from source, and that delegate migration entries exist when the WASM has changed. See Delta's `scripts/check-migration.sh` for the full implementation.
+
+**Wire the gate into the publish task itself, not only into CI.** A check that
+runs in CI but not on the path `publish` actually takes does not gate the moment
+the mistake becomes permanent, and the two drift apart quietly because nothing
+fails when they do. ghostkeys hit this shape while adding its pointer record: the
+cross-check that the registry's author verifying key matches the one published in
+`FREENET.md` lived only in the CI freshness gate, while `sign-webapp` (which
+`publish-ghostkeys` depends on) depends on a *different* script, so a key mismatch
+had no backstop at the one moment it becomes permanent. It was caught in review
+and the check now runs on both paths (freenet/ghostkeys#37). The rule to keep:
+name the task your publish actually depends on and put the gate there, then let
+CI be the second copy.
 
 ## GitHub Actions CI
 

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -671,6 +671,59 @@ hand-rolling another copy of the same sweep.
   reads never learns about it. Route the write through your app's own import
   handler. `SecretStoreIo` keeps the old raw-pair behaviour in one line for
   apps whose secrets genuinely stand alone, behind a deliberately loud ack.
+
+  **Four constraints the crate cannot check for you.** The seam makes correct
+  behaviour possible; it does not make it automatic, and each of these has cost
+  an app its data.
+
+  1. **Never-clobber is your choice, and `UnionAllGenerations` rests entirely on
+     it.** The crate cannot read the successor, so it cannot tell a decline from
+     an overwrite. Return `ItemWrite::AlreadyAuthoritative` for a key the
+     successor already holds. If your import path overwrites instead (the natural
+     shape of an app's own import handler), predecessors are still offered
+     newest-first, so each older generation overwrites the newer value in turn and
+     you end up with the *oldest* generation's value installed and a completely
+     clean report. Either decline held keys or do not use Union.
+  2. **An aggregate secret is read-merge-write, and constraint 1 does not cover
+     it.** An item whose value is a *collection* (an index, a list, a set, a
+     count, a signature over a set) must be merged into what the successor
+     already holds, not resolved by key precedence in either direction. The two
+     ways of getting it wrong are mirror images: declining the write hides
+     entries, which is what never-clobber does to ghostkeys' `gk:index`, and
+     overwriting deletes them, as forwarding a predecessor's `known_sites`
+     straight into Delta's `StoreKnownSites { sites }` would, since that replaces
+     the whole list and so destroys every site the user added on the new version.
+     Only you know which of your secrets are aggregates.
+  3. **Markers must be durable when `record_marker` returns, not batched.**
+     `flush_predecessor` flushes what the *items* were buffered into; the crate
+     never flushes a marker on its own path. Route markers through the same batch
+     as your items and you break twice. A lost `InProgress` marker drops the
+     sticky-data flag, so a retry that finds the predecessor empty seals
+     `Done { had_data: false }`, and `NewestSnapshotWins` then falls through to
+     older generations and resurrects keys the user had deleted. A batched `Done`
+     marker is recorded after the only flush the crate performs, so it is never
+     flushed at all and the predecessor is re-walked and re-imported on every run.
+     Persist markers synchronously, on their own path if necessary.
+  4. **Choose the cross-generation policy deliberately.** `NewestSnapshotWins` is
+     the default and is the right answer for most apps: it preserves
+     delete-by-absence, at the cost of leaving unrecovered any key that only ever
+     existed in a generation older than the authoritative one.
+     `UnionAllGenerations(ack)` is the opt-in recovery mode for exactly that
+     stranded data (freenet/river#204), and it is not a strictly-better setting.
+     It resurrects secrets a newer generation deleted by absence, it inverts
+     silently against an overwriting writer (constraint 1), and its withheld-key
+     set is scoped to a single call, so a flush failure followed by a transiently
+     unreachable newest generation can lose the newest value for good with a clean
+     report (freenet/freenet-migrate#15). Pass one explicitly and know which cost
+     you accepted.
+
+  Two smaller traps in the same adapter. `write_secret` must be **idempotent**:
+  the crate never re-offers items from a *completed* predecessor, but a retry
+  after a partial run re-offers them, so a writer that appends to a list has to
+  insert into a set. And `ItemWrite::AlreadyAuthoritative` is **not an error
+  channel**: an `Err(_) => ...` arm mapped onto it counts as `skipped`, which
+  reads as success, so the predecessor is sealed and never walked again. A write
+  that failed is `Failed { retry }`, and when in doubt it is `Retryable`.
 - **The field evidence comes from the adopters, not from the crate's own
   tests.** The crate's own tests all drive mocked I/O; there is no integration
   test against a real node or a real WASM delegate. Both ghostkeys and Delta gated

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -326,6 +326,33 @@ this pattern; its earlier source-pin-only test had a false positive (it passed
 even with the recovery call deleted), so prefer a pure-function behavioral test
 and verify by mutation that removing the fix fails the test.
 
+**Three questions worth asking of any migration change in review.** Each names a
+failure a green test suite let through.
+
+1. **Does the guard at a seam check BOTH sides of the seam?** A guard that can
+   only see the side it lives on is not a guard. `freenet-migrate`'s newest-wins
+   guarantee is the canonical shape: the crate offers predecessors newest-first,
+   but only the app's writer can see whether the successor already holds a key, so
+   an overwriting writer inverts the guarantee and neither side reports it. When
+   you find a check at a boundary, name what the other side would have to do to
+   defeat it, then confirm something checks that too.
+2. **Is the test double above or below the bug you care about?** A double placed
+   above the layer that can fail proves only that the layers above it agree with
+   each other. `freenet-migrate`'s own tests all drive mocked I/O, with no
+   integration test against a real node or a real WASM delegate, which is why
+   ghostkeys and Delta each gated adoption on a differential test against their
+   prior hand-rolled sweep rather than on the crate's green suite. Put the double
+   below the code under test, or test against the real thing.
+3. **Is the operation idempotent with respect to the UI as well as to stored
+   data?** These are separate properties, and the second is the one that gets
+   missed. Delta's editor bug (freenet/delta#62, fixed in #64) is the shape: the
+   background migration sweep's merge was a genuine no-op for stored data, but it
+   still took the write guard, and Dioxus notifies subscribers on every `write()`
+   whether or not the value changed, so an effect subscribed to that signal
+   re-seeded the editor from persisted state and wiped the user's unsaved typing
+   about five seconds in. Storage idempotence did not save it. Ask what a re-run
+   *renders*, not only what it stores.
+
 ## Staged, reversible rollout
 
 1. Publish the new version to an **isolated key** (a throwaway contract/params)


### PR DESCRIPTION
## Problem

freenet-core#2776's "Skills" section lists three items as outstanding for
`dapp-builder`, and they are genuinely absent from `main`: nothing in `skills/`
mentions never-clobber or `UnionAllGenerations`, nothing records the worktree
build-caching trap, and there are no review questions of this kind. Each item is
a rule paid for by a production bug.

## Approach

Each piece goes where a reader already meets the subject, extending an existing
section rather than opening a new one.

**1. The four constraints on `freenet-migrate`'s writer seam** go in
`delegate-patterns.md`, under "Delegate secret migration: no core mechanism, and
why", attached to the bullet that already introduces `SuccessorSecretsIo`. The
crate decides *what* to migrate and the app supplies the write, so never-clobber,
aggregate merging, marker durability and the cross-generation policy are all
invisible to the crate.

These were written against the crate's own source on `freenet-migrate@origin/main`
(`freenet-migrate/src/delegate_migrate.rs`, `README.md`), not from memory, and the
source corrected one of them:

- **`UnionAllGenerations` is not the default-to-prefer.** `NewestSnapshotWins` is
  the documented safe default and is right for most apps; `UnionAllGenerations`
  is an opt-in recovery mode behind a loud `UnionAck` that *resurrects
  delete-by-absence data*, inverts silently against an overwriting writer, and
  carries a run-scoped withheld-key hazard (freenet/freenet-migrate#15). So the
  rule written is "choose the policy deliberately and know its cost", not "pass
  `UnionAllGenerations`".
- Never-clobber is also narrower than "never overwrite": it is the *implementer's*
  choice, the crate cannot check it, and it is the wrong answer for an aggregate,
  which is what makes constraints 1 and 2 distinct rather than one rule.

**2. Two operational facts** go in `build-system.md`: the worktree
build-caching trap plus the `cargo:`-parses-stdout-only corollary into "Build
Verification" (the section that already shows a `build.rs` emitting
`rerun-if-changed`), and the publish-path gate into "Pre-Publish Checks" (which
already shows `[tasks.publish]` depending on `preflight`).

**3. Three review questions** are appended to "Test the upgrade path, not just
the new version" in `upgrade-and-migration.md`, which already teaches that a
source-scrape pin can be a false positive.

## Verification

- Every claim about `freenet-migrate` is quoted from its `origin/main` docs.
- The Delta and ghostkeys incidents were verified against those repos rather than
  restated: Delta's stale legacy-delegate table is #52/#53, the worktree fix is
  #58, the editor bug is #62 fixed in #64. The ghostkeys divergence
  (CI freshness gate vs. the `sign-webapp` publish path) is real and is described
  here as what it was: a finding caught in review and closed inside #37, not a
  live gap.
- Checked `git grep` on `origin/main` for every distinctive term added
  (`AlreadyAuthoritative`, `record_marker`, `flush_predecessor`,
  `NewestSnapshotWins`, `StoreKnownSites`, `gk:index`, `rev-parse --git-path`,
  `always-dirty`, "test double"): zero pre-existing hits, so nothing here
  duplicates guidance already in the skill. `read-merge-write` does appear once
  already, in `upgrade-and-migration.md`'s CAS bullet, which is the contract-side
  re-migration property and a different mechanism from the delegate aggregate
  secret; the new text is in `delegate-patterns.md` and is scoped to the adapter.

Version bumped to 1.26.0 with a matching CHANGELOG entry.

Refs freenet/freenet-core#2776

[AI-assisted - Claude]
