### PR TITLE
docs(dapp-builder): floor durability, and a gap that is silent on both sides (v1.27.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.26.0"
+    "version": "1.27.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.27.0 (2026-08-19)
+
+Two additions to `building-on-other-apps.md`, both from the delegate-succession
+work, which is the first consumer to treat a pointer record as an authorization
+input rather than as an address. That raises the bar on two things the file
+previously stated too weakly.
+
+- **How durable the anti-rollback floor must be.** "Persist it" invites
+  `localStorage`, which an attacker can clear. The rule is now a test: the floor
+  must be at least as durable as whatever it guards, and stored beside it,
+  because clearing the floor is exactly as useful to an attacker as defeating
+  it. With the reassuring corollary, so nobody defends against it: a freshly
+  installed old version has an empty floor AND an empty store, so floor and data
+  are born together and the danger is only in separating them later.
+- **The scope note now names a failure that is silent on both sides.** Freenet's
+  host secret enumeration is best-effort by design: `list_secret_keys` calls
+  `unwrap_or_default()` on an unreadable registry and returns an EMPTY LIST
+  rather than an error, and `register_key` can store a value while declining to
+  register it, warning only on the node. So a handover can enumerate, ship what
+  it found, report an honest success, and still have moved a subset, with
+  nothing the user or the app can inspect. Verified in freenet-core's
+  `secrets_store/store.rs` (`list_secret_keys` at :1508, the cap
+  `MAX_REGISTERED_KEYS_PER_SCOPE = 4096` at :102), not taken from a summary.
+  The rule that falls out: treat "the data arrived" as a separate claim needing
+  its own evidence, and never infer it from the mover reporting success.
+
 ## 1.26.0 (2026-08-19)
 
 Three gaps freenet-core#2776 lists as outstanding for this skill.

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -167,6 +167,27 @@ version, your floor stays at the pre-withdrawal value and any peer can serve a
 real, validly signed pre-withdrawal record that resurrects code the author
 explicitly withdrew.
 
+**How durable does the floor need to be? At least as durable as whatever it
+guards, and stored next to it.** "Persist it" is not a strong enough
+instruction, because it invites `localStorage`, which an attacker can clear and
+a user can clear by accident. Use this test instead: a floor that outlives the
+thing it protects is merely wasteful, while a floor that dies before it is a
+hole, because clearing the floor is exactly as good to an attacker as defeating
+it. So a resolver holding nothing but a cached address can keep its floor
+wherever that address lives, and a consumer using the record to gate access to
+secrets must keep the floor in the same store as those secrets. Co-location is
+the point: the two must be lost together or not at all, or "clear the floor,
+then replay an old record" becomes a working attack.
+
+The corollary is reassuring, and worth stating so nobody builds a defence
+against it: a freshly installed OLD version cannot be exploited this way. That
+instance starts with an empty floor AND an empty store, so there is nothing to
+steal. The floor and the data it guards are born together; the danger is only
+in separating them afterwards.
+
+(Rule contributed by the delegate-succession work, where the record gates a
+transfer of secrets rather than naming an address.)
+
 **4. Handle every arm.** `PointerOutcome` has seven variants and only two carry
 a record. The tempting shape
 
@@ -233,6 +254,24 @@ an integrator who resolves River's delegate pointer correctly, and then assumes
 the user's secrets came with it, will be wrong for every secret in that
 namespace. Resolving the pointer correctly is necessary for a safe upgrade and
 nowhere near sufficient.
+
+Worse, the gap can be **silent on both sides**, so neither you nor the app you
+depend on learns anything went wrong. Freenet's host-side secret enumeration is
+best-effort by design, and its own source says so: `list_secret_keys` calls
+`unwrap_or_default()` on an unreadable key registry, so it returns an **empty
+list** rather than an error, and `register_key` can store a value while
+declining to register it (an unreadable registry, or a 4096 live-key ceiling),
+warning only on the node. So a handover that enumerates what it holds, ships
+what it finds, and reports success can move a subset and be unable to tell.
+Resolve the pointer perfectly, derive the right key, receive an honest success,
+and still find data missing, with no error anywhere and nothing the user can
+inspect. (Verified in `secrets_store/store.rs` as of 2026-08. Neither River nor
+ghostkeys is exposed today, because both use their own app-level protocols
+rather than host enumeration; a design that enumerates directly is.)
+
+The rule that falls out: **treat "the data arrived" as a separate claim needing
+its own evidence.** Never infer it from a successful resolve, and never infer it
+from the mover reporting success either.
 
 What you *do* get, and it is the thing that was missing in the ghostkeys
 incident, is the ability to tell **"the thing I was built against moved"** apart


### PR DESCRIPTION
## Problem

Both additions come from the delegate-succession work, which is the first consumer to treat a pointer record as an **authorization input** rather than as an address. That raises the bar on two things this file previously stated too weakly.

**1. "Persist the floor" is not a strong enough instruction.** It invites `localStorage`, which an attacker can clear and a user can clear by accident. For a consumer gating access to secrets, clearing the floor is exactly as useful to an attacker as defeating it, so the storage location is part of the security property rather than an implementation detail.

**2. The scope note said a pointer "says nothing about whether data survived", but not that the gap can be silent in both directions.** A reader could reasonably assume that if the move failed, someone would know.

## Approach

The floor rule is now a **test** rather than an instruction: the floor must be at least as durable as whatever it guards, and stored beside it. A floor that outlives its data is merely wasteful; one that dies first is a hole. Includes the corollary, so nobody builds a defence against it: a freshly installed old version starts with an empty floor **and** an empty store, so the two are born together and the danger is only in separating them afterwards.

The scope note now names a concrete, verified instance. Freenet's host secret enumeration is best-effort by design:

- `list_secret_keys` calls `unwrap_or_default()` on an unreadable registry and returns an **empty list** rather than an error. Its own source comment says so.
- `register_key` can store a value while declining to register it (unreadable registry, or the live-key cap), warning only on the node.

So a handover can enumerate what it holds, ship what it finds, report an honest success, and still have moved a subset, with no error anywhere and nothing the user or the app can inspect. The rule that falls out: treat "the data arrived" as a separate claim needing its own evidence, and never infer it from a successful resolve **or** from the mover reporting success.

Neither River nor ghostkeys is exposed today, because both use app-level protocols rather than host enumeration. A design that enumerates directly is, which is stated in the text.

## Testing

Docs only. Every claim verified against freenet-core `origin/main` rather than taken from a summary: `list_secret_keys` at `crates/core/src/wasm_runtime/secrets_store/store.rs:1508` with the `unwrap_or_default()` at :1520, `register_key`'s two early returns, and `MAX_REGISTERED_KEYS_PER_SCOPE = 4096` at :102. `marketplace.json` re-parsed as valid JSON at 1.27.0; CHANGELOG entry added at the top.

[AI-assisted - Claude]