### PR TITLE
docs(dapp-builder): who actually needs a pointer, and why River is an exception (v1.28.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.27.0"
+    "version": "1.28.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.28.0 (2026-08-21)
+
+The guide taught HOW to resolve a pointer but never WHO should, so a reader had
+no way to tell whether it applied to them. Adding resolution where it cannot help
+buys a network dependency and a new failure path in exchange for nothing.
+
+- **The pinned-in-time test.** You need a pointer if a copy of your code can still
+  be running long after the artifact it addresses has moved: anything installed,
+  vendored or bundled, and anything deployed on its own schedule. You do not, on
+  engineering grounds, if you are rebuilt and redelivered whenever that artifact
+  changes, which is the ordinary case for a Freenet web app served from a
+  container republished in place.
+- **Vendoring a copy is the same trap with an extra step**, and looks like a build
+  artifact rather than a stale reference. One app in this ecosystem vendored a
+  delegate six generations and three months stale and registered it on startup.
+- **A backward-searching recovery cannot rescue a stale anchor.** If your idea of
+  "current" is out of date, the live state is FORWARD of everywhere your probe
+  looks, and you may write an ancient copy onto a retired address. A build-time
+  assertion that your bundled hash is current protects the binary when built, not
+  when run.
+- **River's UI is documented as a deliberate exception rather than left as a
+  contradiction.** It resolves despite the test saying it need not, because it is
+  the reference people read when learning to build Freenet apps. Copying that
+  choice means copying its constraint: resolving forward inverts the
+  compatibility direction, so an old client can meet newer state, and the
+  dangerous half is WRITING, not reading. The bound to adopt is refusing to write
+  to an unrecognised generation and staying read-only until reloaded.
+
 ## 1.27.0 (2026-08-19)
 
 Two additions to `building-on-other-apps.md`, both from the delegate-succession

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -91,6 +91,64 @@ Mechanics, wire format, and the operational requirements are in the contract's
 own README — do not restate them here, or the two copies drift:
 <https://github.com/freenet/freenet-migrate/blob/main/contracts/pointer-contract/README.md>
 
+## Do you actually need one? The pinned-in-time test
+
+Resolving is not free, and adding it where it cannot help buys you a network
+dependency and a new failure path in exchange for nothing. One question decides
+it:
+
+**Are you pinned in time relative to the thing you address?**
+
+You are pinned, and you need a pointer, if a copy of your code can still be
+running long after the artifact it addresses has moved. The clearest case is a
+CLI installed from a registry: `riverctl` is installed from crates.io and kept
+for months, so the contract generation compiled into it silently becomes older
+than the live one. Anything a user installs, vendors, or bundles is in this
+group, and so is any server or bot deployed on its own schedule.
+
+You are NOT pinned, on engineering grounds alone, if you are rebuilt and
+redelivered whenever the thing you address changes. A Freenet web app is the
+usual example: it ships inside a web container republished in place, and changing
+the contract forces a UI rebuild and republish, so the UI's idea of "current"
+cannot lag reality. Resolving your own artifact's pointer there is close to
+circular, since the answer is already compiled into you.
+
+Two things make this test sharper than it first looks.
+
+**Vendoring a copy is the same trap with an extra step.** Committing another
+project's WASM into your repo pins you exactly as hardcoding its key would, and
+it looks like a build artifact rather than a stale reference. One app in this
+ecosystem vendored a delegate that was six generations and three months stale,
+and registered it on every startup.
+
+**A backward-searching recovery cannot rescue a stale anchor.** If your migration
+walks *older* generations from where you think "current" is, and your idea of
+current is itself out of date, the live state is FORWARD of everywhere you will
+look. You will not merely miss it; you may find an ancient copy and write it
+forward onto a retired address. A build-time assertion that your bundled hash is
+current cannot help here, because it protects the binary when it is built, not
+when it is run.
+
+### The deliberate exception: River's UI
+
+River's UI resolves its pointer even though the test above says it does not need
+to. That is a considered decision by the project lead, not a counterexample, and
+the reason is that River's UI is the reference people read when learning to build
+Freenet apps: it should demonstrate the mechanism it recommends. It also buys a
+real capability, shipping a contract upgrade without republishing the UI.
+
+If you copy that choice, copy its constraint too. Resolving forward means an old
+copy of your app can meet a NEWER artifact, which inverts the compatibility
+direction: ordinarily new code reads old state, and here old code must cope with
+new state. The dangerous half is not reading but WRITING, because an old client
+that parses new state, silently drops what it does not understand, merges and
+writes back has destroyed those fields while reporting success.
+
+The bound worth adopting is the one in the outcome table below: **refuse to write
+to a generation you do not recognise, and stay read-only until reloaded.** That
+removes the round-trip destruction without requiring you to promise forward
+compatibility forever.
+
 ## Resolving one
 
 ```rust


### PR DESCRIPTION
## Problem

`building-on-other-apps.md` taught **how** to resolve a pointer record but never **who should**, so a reader had no way to tell whether it applied to them. That is not a neutral omission: adding resolution where it cannot help buys a network dependency and a new failure path in exchange for nothing.

It became urgent rather than tidy when River's UI was approved to resolve. A reader applying the general engineering rule would conclude the opposite of what River now does, and the guide would be silently contradicted by its own reference app.

## Approach

**One question decides it: are you pinned in time relative to the thing you address?**

You need a pointer if a copy of your code can still be running long after the artifact it addresses has moved. A CLI installed from crates.io is the clearest case. You do not, on engineering grounds, if you are rebuilt and redelivered whenever that artifact changes, which is the ordinary case for a Freenet web app served from a container republished in place.

Two sharpenings, both drawn from real incidents rather than invented:

- **Vendoring a copy is the same trap with an extra step**, and it looks like a build artifact rather than a stale reference. One app in this ecosystem vendored a delegate six generations and three months stale and registered it on every startup.
- **A backward-searching recovery cannot rescue a stale anchor.** If your idea of "current" is itself out of date, the live state is FORWARD of everywhere your probe looks. You may not merely miss it, you may find an ancient copy and write it forward onto a retired address. A build-time assertion that your bundled hash is current cannot help, because it protects the binary when it is built, not when it is run.

**River's UI is documented as a deliberate exception**, not left as a contradiction. It resolves despite the test saying it need not, because it is the reference people read when learning to build Freenet apps, and it buys shipping a contract upgrade without republishing the UI.

Anyone copying that choice is told to copy its constraint. Resolving forward inverts the compatibility direction: ordinarily new code reads old state, here old code can meet new state. The dangerous half is **writing**, not reading, because an old client that parses new state, drops what it cannot see, merges and writes back has destroyed those fields while reporting success. The bound to adopt is the one already in the outcome table: refuse to write to a generation you do not recognise, and stay read-only until reloaded. That removes the round-trip destruction without promising forward compatibility forever.

## Testing

Docs only. No em-dashes in the added text. `marketplace.json` re-parsed as valid JSON at 1.28.0, CHANGELOG entry at the top.

The commitment terms this summarises are recorded in full in [freenet-core#2776](https://github.com/freenet/freenet-core/issues/2776), including the failure-mode plan per `PointerOutcome` arm and the pre-user verification plan, since Ian has accepted a standing obligation and should be able to see its actual terms.

[AI-assisted - Claude]