### PR TITLE
docs(dapp-builder): make TS subscribe/disconnect promise claim version-explicit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.28.0"
+    "version": "1.28.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.28.1 (2026-08-22)
+
+Corrects the TypeScript client docs' claim about `subscribe`/`disconnect`,
+and makes the claim version-explicit so it doesn't go wrong again as
+freenet-stdlib ships.
+
+`ui-patterns.md` and `SKILL.md` said stdlib TS made `subscribe` and
+`disconnect` promise-based the same way as `get`/`put`/`update` — resolving
+on the matching response, rejecting on timeout/close/host-error. Checked
+against freenet-stdlib's `typescript/src/websocket-interface.ts`: on every
+npm-published version through 0.3.0 (latest on the registry as of
+2026-08-22), `get`/`put`/`update` really do await a per-request
+pending-queue entry, but `subscribe()` and `disconnect()` just call the
+synchronous `sendRequest()` and return — the promise resolves on send, never
+on response, so it can't catch a subscribe failure (e.g. the per-client
+subscription cap). A developer hit exactly this: their subscribe failures
+were silently invisible because a `try/catch` around `await api.subscribe()`
+can never fire on those versions.
+
+While this fix was in flight, freenet-stdlib PR #94 landed on `main`
+(2026-08-22) making `subscribe()` genuinely correlate to its response —
+ships as TS package **0.4.0**, not yet published to npm. `disconnect()` is
+untouched by #94 and stays fire-and-forget in every version.
+
+- `ui-patterns.md` and `SKILL.md` now state both behaviors explicitly by
+  version: pre-0.4.0 (the callback-based workaround via
+  `onSubscribeResponse`/`onErr`) and 0.4.0+ (the `try/catch` pattern is
+  correct).
+- `disconnect` is documented as resolving on send in every version, with no
+  version caveat needed.
+
 ## 1.28.0 (2026-08-21)
 
 The guide taught HOW to resolve a pointer but never WHO should, so a reader had

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -488,13 +488,19 @@ matching `@freenetorg/freenet-stdlib` release:
 ```
 
 The TS package v0.2.0 brought the API to parity with the Rust client:
-`FreenetWsApi` with **promise-based** `get`/`put`/`update`/`subscribe`/
-`disconnect` (`await api.X(...)`), full `ResponseHandler` including
-`onContractNotFound`/`onSubscribeResponse`/`onClose`, inbound
-`ReassemblyBuffer`, and transparent outbound chunking for payloads
->512 KB. Callbacks still fire alongside promises for backward
-compatibility; the default request timeout is 30 s. See
-`references/ui-patterns.md` for the full pattern and a warning about the
+`FreenetWsApi` with **promise-based** `get`/`put`/`update`
+(`await api.X(...)`, resolves/rejects on the matching response), full
+`ResponseHandler` including `onContractNotFound`/`onSubscribeResponse`/
+`onClose`, inbound `ReassemblyBuffer`, and transparent outbound chunking
+for payloads >512 KB. Callbacks still fire alongside the promise-based
+calls for backward compatibility; the default request timeout is 30 s.
+`subscribe` is also promise-based **from TS package 0.4.0** (resolves/
+rejects on the matching `SubscribeResponse`); on the npm-published 0.3.0
+and earlier it resolves as soon as the request is sent, never on the
+host's response — use the `ResponseHandler` callbacks to detect a refused
+subscribe on those versions. `disconnect` resolves on send in every
+version. See `references/ui-patterns.md` for the full pattern (including
+which stdlib version you need for which behavior) and a warning about the
 private `sendRequest` cast used for delegate messages until a public
 builder lands.
 

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -649,7 +649,11 @@ const handler: ResponseHandler = {
   onContractNotFound: (instanceId) => {
     console.warn("[freenet] Contract not found:", instanceId);
   },
-  // Added in stdlib v0.2.0: fired on SUBSCRIBE confirmation (subscribed flag = success)
+  // Added in stdlib v0.2.0: fired on SUBSCRIBE confirmation (subscribed flag = success).
+  // On stdlib TS >= 0.4.0 this fires alongside the api.subscribe() promise, which now
+  // also resolves/rejects on this same response. On older versions (0.3.0 and below,
+  // still the published npm version as of 2026-08-22) this callback is the only way
+  // to detect a refused subscribe. See "Contract Operations" below.
   onSubscribeResponse: (key, subscribed) => {
     console.log("[freenet] Subscribe:", key.encode(), "ok=", subscribed);
   },
@@ -689,7 +693,13 @@ const contractKey = new ContractKey(instanceBytes, instanceBytes);
 
 ### Contract Operations
 
-stdlib TS v0.2.0 made `get`, `put`, `update`, `subscribe`, and `disconnect` **promise-based**. They resolve with the typed response, reject on timeout (default 30s), connection close, or host error. The legacy callbacks in `ResponseHandler` still fire for the same response — both APIs coexist for backward compatibility.
+stdlib TS v0.2.0 made `get`, `put`, and `update` **promise-based**. They resolve with the typed response, reject on timeout (default 30s), connection close, or host error. The legacy callbacks in `ResponseHandler` still fire for the same response — both APIs coexist for backward compatibility.
+
+**`subscribe` is version-dependent — check which stdlib TS version you're on.** As of freenet-stdlib PR #94 (merged 2026-08-22, ships as TS package **0.4.0**), `subscribe()` correlates to its response the same way: it resolves on `SubscribeResponse{subscribed:true}` and rejects on `subscribed:false`, a host error naming the contract, connection close, or timeout — the `try/catch` pattern in the example below is correct from 0.4.0 on. **Before 0.4.0** (every version published to npm as of 2026-08-22 — the registry's latest is still 0.3.0), `subscribe()` just calls the synchronous `sendRequest()` and returns: the promise resolves as soon as the request is *sent*, never on the host's response, so it can't reject on a refused subscribe (e.g. hitting the node's per-client subscription cap of 50). On a pre-0.4.0 version, detect the real outcome via the `ResponseHandler` callbacks instead — `onSubscribeResponse` for success/failure the host reports back, `onErr` for a host-level error.
+
+`disconnect` is untouched by #94: in every version it resolves as soon as the request is sent, not on any response — there's no pending-request queue for it the way `pendingGets`/`pendingPuts`/`pendingUpdates`/`pendingSubscribes` back the others.
+
+#94 also narrowed host-error handling: from 0.4.0, a host error only rejects in-flight requests for the contract it names (previously any host error rejected every pending request on the connection), and concurrent requests for different contracts can no longer cross-resolve with each other's responses.
 
 ```typescript
 // GET — fetch current state (await + try/catch)
@@ -703,7 +713,16 @@ try {
   console.error("[freenet] GET failed:", err); // timeout / not-found / closed
 }
 
-// SUBSCRIBE — receive real-time updates (promise resolves on SubscribeResponse)
+// SUBSCRIBE — receive real-time updates.
+// stdlib TS >= 0.4.0: api.subscribe() resolves on SubscribeResponse{subscribed:true}
+// and rejects on subscribed:false / a host error / connection close / timeout —
+// this try/catch is correct.
+// stdlib TS < 0.4.0 (still the published npm version as of 2026-08-22): the
+// promise resolves as soon as the request is SENT and never rejects on a
+// refused subscribe (e.g. the per-client subscription cap). On that version,
+// detect failure via the ResponseHandler callbacks instead:
+//   onSubscribeResponse: (key, subscribed) => { if (!subscribed) { /* failed */ } }
+//   onErr: (err) => { /* host-level error, e.g. limit reached */ }
 try {
   await api.subscribe(new SubscribeRequest(contractKey, []));
 } catch (err) {


### PR DESCRIPTION
## Problem

`skills/dapp-builder/references/ui-patterns.md` and `skills/dapp-builder/SKILL.md` claimed stdlib TS made `get`, `put`, `update`, `subscribe`, and `disconnect` uniformly promise-based — resolving with the typed response, rejecting on timeout/close/host error.

Verified against freenet-stdlib: `get`/`put`/`update` genuinely `await` a per-request pending queue that resolves on the matching `HostResponse`. `subscribe()`/`disconnect()` did not, as of the npm-published 0.3.0 (still the registry's latest as of 2026-08-22) — they called the synchronous `sendRequest()` and returned, so the promise resolved on *send*, never on the host's response. A `try/catch` around `await api.subscribe()` could never catch a refused subscribe (e.g. the node's per-client subscription cap of 50). This caused real confusion: a developer following the doc could not tell why subscribe failures were invisible to their app.

**While this PR was in flight, freenet-stdlib#94 merged** (2026-08-22, commit `112a06e`), fixing exactly this on the `subscribe()` side: it now correlates to its `SubscribeResponse` the same way `get`/`put`/`update` do. That ships as TS package **0.4.0**, not yet published to npm. `disconnect()` is untouched by #94 and stays fire-and-forget in every version.

## Approach

Rather than flatly restate one behavior, the docs are now explicit about which stdlib TS version each behavior applies to:

- **Before 0.4.0** (every currently-published npm version): `subscribe()` resolves on send, never rejects on a refused subscribe. Detect failure via the `onSubscribeResponse`/`onErr` `ResponseHandler` callbacks.
- **0.4.0+**: `subscribe()` resolves/rejects on the matching `SubscribeResponse` — the `try/catch` pattern is correct.
- **`disconnect()`**: resolves on send in every version, no caveat needed.

Also noted (from #94): a host error now scopes to the contract it names instead of failing every in-flight request, and out-of-order responses no longer cross-resolve between concurrent requests for different contracts.

Bumped `.claude-plugin/marketplace.json` to **1.28.1** (patch: doc correction) and updated `CHANGELOG.md`, per this repo's CI version-bump gate. (Note: this branch was originally cut from a stale local `main`, which produced a `1.25.1` version conflict against the real `main` at `1.28.0` — rebased and re-bumped to `1.28.1`, squashed to one commit.)

## Testing

Documentation-only change. Claims verified against the actual `freenet-stdlib` source at `origin/main` (not assumed), including re-checking after `#94` merged mid-review. `check-version` and `license/cla` CI both green on the current head.

[AI-assisted - Claude]