### PR TITLE
docs(dapp-builder): cross-contract reads are implemented, and what limits them (v1.29.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.28.1"
+    "version": "1.29.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ at `runtime.rs:946` no longer exists anywhere in that file.
   `freenet-scaffold`'s `#[composable]` has no inter-contract awareness
   (freenet-core#2870).
 
+`references/state-authorization-patterns.md` already documented the mechanism
+and its limits, so SKILL.md was contradicting its own reference file; SKILL.md
+now points at it. That reference told authors to do cross-contract auth in
+`validate_state` because `update_state` has no `related` parameter. The
+premise is literally true and the conclusion is now the worse advice:
+`UpdateModification::requires(vec![...])` exists (stdlib
+`src/contract_interface/update.rs:51`) and the host re-invokes `update_state`
+with the results as `UpdateData::RelatedState`, and that is the path
+conformance can actually see. Section rewritten, with `validate_state` kept as
+the documented backstop.
+
 Also corrects two stale version claims found while checking the first:
 
 - "As of May 2026 — River pins `freenet-stdlib = "0.6.0"` but the upstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.29.0 (2026-08-28)
+
+Corrects the `dapp-builder` claim that contracts cannot read each other's
+state, and adds the constraint that actually governs when you may.
+
+The skill said "Contracts reading other contracts' state is planned but not
+yet implemented". That is wrong and it misled a reader today. Verified
+against freenet-core `main`: `validate_state` can return
+`ValidateResult::RequestRelated(Vec<ContractInstanceId>)`, and
+`fetch_related_for_validation_network`
+(`crates/core/src/contract/executor/runtime/contract_ops.rs`) resolves those
+ids and re-invokes with `RelatedContracts` populated, on both the PUT and
+UPDATE paths. The supporting machinery is real, not a stub: off-loop
+deferral bounded by `MAX_INFLIGHT_DEFERRALS = 256`, an RAII `ResumeGuard`
+giving exactly-once resume, and backpressure that surfaces `MissingRelated`
+rather than growing unboundedly (freenet-core#4391). freenet-core#2870 is
+still open but is itself partly stale — the UPDATE-path `todo!()` it cites
+at `runtime.rs:946` no longer exists anywhere in that file.
+
+- The load-bearing addition is the safety rule, not the capability. A
+  contract's verdict must be a function of its inputs or replicas diverge,
+  so reading an immutable or once-true-always-true fact is safe, and gating
+  validity on mutable or growing state is not — "reject if the other party
+  has more than N entries" flips as their state grows, and peers validating
+  at different moments never converge. That belongs in client-side policy.
+- Documents the practical limits: one round only (a `RequestRelated` is
+  fetched and retried exactly once, `contract_ops.rs:431-432`, capped at
+  `MAX_RELATED_CONTRACTS_PER_REQUEST = 10`), `RelatedStateAndDelta` is the
+  client-submittable UPDATE form while bare `RelatedState`/`RelatedDelta`
+  are runtime-internal, a related fetch that times out can wedge an UPDATE
+  merge (freenet-core#4077), related state resolved during *validation* is
+  never captured by the conformance system so such a contract is
+  unjudgeable and reads exactly like a clean one (freenet-core#5376), and
+  `freenet-scaffold`'s `#[composable]` has no inter-contract awareness
+  (freenet-core#2870).
+
+Also corrects two stale version claims found while checking the first:
+
+- "As of May 2026 — River pins `freenet-stdlib = "0.6.0"` but the upstream
+  crate is now `0.8`" is out of date in both halves. River's workspace
+  `Cargo.toml` pins `0.8.5`, which is the current crates.io release, so the
+  reference dApp and upstream no longer diverge. The "track this against
+  stdlib 0.8 once River bumps" conditional is dropped.
+- The security section attributed the `DEFAULT_CIPHER` / `DEFAULT_NONCE`
+  removal to stdlib v0.6.0. Both constants are still present in the
+  published 0.6.0 and 0.6.1 sources and gone by 0.8.2; freenet-stdlib PR #75
+  merged 2026-05-16T18:00Z and 0.8.0 was published four minutes later, so
+  the removal shipped in **0.8.0**. Code referencing them fails against 0.8
+  or newer, not 0.6 or newer. The upgrade note now says 0.6 → 0.8 rather
+  than stepping through 0.7, which was never published to crates.io.
+
 ## 1.28.1 (2026-08-22)
 
 Corrects the TypeScript client docs' claim about `subscribe`/`disconnect`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@ Also corrects two stale version claims found while checking the first:
   the removal shipped in **0.8.0**. Code referencing them fails against 0.8
   or newer, not 0.6 or newer. The upgrade note now says 0.6 → 0.8 rather
   than stepping through 0.7, which was never published to crates.io.
+- The same sweep over `references/`: `build-system.md` carried a
+  "(0.6→0.7→0.8)" comment attributing changes to a release that never
+  shipped, and its workspace stanza plus `ui-patterns.md` pinned `0.8`,
+  `0.6.0` and `dioxus 0.7.3` while claiming to mirror River. River pins
+  `freenet-stdlib 0.8.5` (workspace) and `dioxus 0.7.9` (`ui/Cargo.toml`);
+  those four pins now say so. The `=0.8.0` pin in `build-system.md`'s
+  contract-crate example is deliberately left alone — that section teaches
+  pinning every WASM-affecting dependency with `=x.y.z` for contract-ID
+  reproducibility, and every dependency in the example is a frozen exact
+  pin, so the numbers illustrate the technique rather than tracking a
+  release.
 
 ## 1.28.1 (2026-08-22)
 

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -505,7 +505,7 @@ freenet-scaffold-macro = "0.2.2"
 freenet-stdlib = { workspace = true, features = ["net"] }
 
 # UI framework
-dioxus = { version = "0.7.3", features = ["web"] }
+dioxus = { version = "0.7.9", features = ["web"] }
 ```
 
 The `contract` feature is required for contract crates targeting

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -181,6 +181,10 @@ Practical limits:
 - `freenet-scaffold`'s `#[composable]` has no inter-contract awareness
   (freenet-core#2870), so cross-contract dependencies are hand-rolled.
 
+The mechanism with code, and which of the two paths to request related state
+from, is in `references/state-authorization-patterns.md` →
+"Related-Contracts Mechanism".
+
 ---
 
 ## Development Workflow

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -140,7 +140,46 @@ Every rule below is checkable in review and grounded in a measured finding from 
 ## Advanced Capabilities
 
 - **Subscriptions:** Clients can subscribe to contracts and get notified of changes immediately (real-time apps)
-- **Contract Interoperability:** Contracts reading other contracts' state is planned but not yet implemented
+- **Contract Interoperability:** Cross-contract reads are implemented and working.
+  `validate_state` can return `ValidateResult::RequestRelated(Vec<ContractInstanceId>)`;
+  the host fetches those contracts and re-invokes with `RelatedContracts` populated
+  (`fetch_related_for_validation_network` in
+  `crates/core/src/contract/executor/runtime/contract_ops.rs`, on both the PUT and
+  UPDATE paths). The machinery behind it is real: a related fetch that would block the
+  serial contract loop is deferred to an off-loop waiter, bounded by
+  `MAX_INFLIGHT_DEFERRALS = 256` with an RAII guard giving exactly-once resume, and an
+  over-cap op surfaces `MissingRelated` rather than growing unboundedly
+  (freenet-core#4391, `crates/core/src/contract.rs`). freenet-core#2870 ("Complete
+  related contract mechanism implementation") is still open but is itself partly stale —
+  the UPDATE-path `todo!()` it cites at runtime.rs:946 no longer exists.
+
+**The thing to get right is not whether it works, but what you are allowed to read.**
+A contract's verdict must be a function of its inputs, or replicas diverge. Reading
+another contract widens the input set to something that changes underneath you:
+
+- Reading an **immutable** fact (a certificate, a signed key) is safe — every peer gets
+  the same answer forever.
+- Reading a **monotonic** fact in the once-true-always-true direction is safe.
+- **Gating validity on mutable or growing state is not.** "Reject if the other party has
+  more than N entries" flips from valid to invalid as their state grows, so peers
+  validating at different moments disagree and never converge. That class of rule belongs
+  in client-side policy, not in `validate_state`.
+
+Practical limits:
+
+- **One round only.** A `RequestRelated` is fetched and retried **exactly once**; a
+  second is an error (`contract/executor/runtime/contract_ops.rs:431-432`), capped at
+  `MAX_RELATED_CONTRACTS_PER_REQUEST = 10` ids. No chained dependencies.
+- On the client-facing UPDATE surface, `UpdateData::RelatedStateAndDelta` is the form
+  you send; bare `UpdateData::RelatedState` / `RelatedDelta` are rejected from
+  `ContractRequest::Update` and reserved for the runtime's own request-related
+  orchestration, which surfaces `RelatedState` to your WASM itself.
+- A related fetch that times out can wedge an UPDATE merge (freenet-core#4077, open).
+- Related state resolved during *validation* is never captured by the conformance
+  system (freenet-core#5376, open), so a contract that depends on that path is
+  unjudgeable — and an unjudgeable contract reads exactly like a clean one.
+- `freenet-scaffold`'s `#[composable]` has no inter-contract awareness
+  (freenet-core#2870), so cross-contract dependencies are hand-rolled.
 
 ---
 
@@ -443,18 +482,18 @@ deserialization failures, missing features, and "variant index out of range"
 errors. Check [River's workspace Cargo.toml](https://github.com/freenet/river/blob/main/Cargo.toml)
 before pinning.
 
-As of May 2026 — River pins `freenet-stdlib = "0.6.0"` but the upstream
-crate is now `0.8` (0.6 → 0.7 added Base58-stringified `contract_states`
-keys in `NodeDiagnosticsResponse`; 0.7 → 0.8 hardened wire-boundary enums
-with `#[non_exhaustive]` and removed the world-known `DEFAULT_CIPHER` /
-`DEFAULT_NONCE` constants). If you build only against River, mirror its
-pin; if your code links into stdlib 0.8 directly, you need the bumped
-version *and* the wildcard match arms / random cipher generation
-documented in `references/delegate-patterns.md`.
+As of August 2026 — River pins `freenet-stdlib = "0.8.5"`, which is the
+current crates.io release, so River and upstream no longer diverge. If you
+are moving code off an older pin, the step is 0.6 → 0.8 (no 0.7 was ever
+published to crates.io): it added Base58-stringified `contract_states` keys
+in `NodeDiagnosticsResponse`, hardened wire-boundary enums with
+`#[non_exhaustive]`, and removed the world-known `DEFAULT_CIPHER` /
+`DEFAULT_NONCE` constants, so you need the wildcard match arms / random
+cipher generation documented in `references/delegate-patterns.md`.
 
 ```toml
-# Workspace-wide (Cargo.toml) — track this against stdlib 0.8 once River bumps.
-freenet-stdlib = { version = "0.8", features = ["contract"] }
+# Workspace-wide (Cargo.toml) — matches River pin.
+freenet-stdlib = { version = "0.8.5", features = ["contract"] }
 freenet-scaffold = "0.2.2"
 freenet-scaffold-macro = "0.2.2"
 
@@ -506,13 +545,14 @@ builder lands.
 
 ### Security: removed encryption defaults
 
-stdlib v0.6.0 (PR #75) **removed** the public constants `DEFAULT_CIPHER`
+stdlib v0.8.0 (PR #75) **removed** the public constants `DEFAULT_CIPHER`
 and `DEFAULT_NONCE` to close a CVE-class issue (world-known keys leaked
-into any binary that imported them). Delegates that previously used these
+into any binary that imported them). They are still present in 0.6.0 and
+0.6.1. Delegates that previously used these
 must now generate random values per session — e.g.
 `let key: [u8; 32] = rand::random(); let nonce: [u8; 24] = rand::random();`.
 Code still referencing the old constants will fail to compile against
-stdlib 0.6 or newer.
+stdlib 0.8 or newer.
 
 ---
 

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -316,8 +316,9 @@ resolver = "2"
 [workspace.dependencies]
 # Mirror River's pinned versions; bump together when upgrading. Check
 # https://github.com/freenet/river/blob/main/Cargo.toml before pinning.
-# stdlib bumped to 0.8 to track current freenet-stdlib release (0.6→0.7→0.8).
-freenet-stdlib = { version = "0.8", features = ["contract"] }
+# stdlib 0.8.5 tracks the current freenet-stdlib release (0.6 → 0.8; no 0.7
+# was ever published to crates.io).
+freenet-stdlib = { version = "0.8.5", features = ["contract"] }
 freenet-scaffold = "0.2.2"
 freenet-scaffold-macro = "0.2.2"
 serde = { version = "1", features = ["derive"] }

--- a/skills/dapp-builder/references/state-authorization-patterns.md
+++ b/skills/dapp-builder/references/state-authorization-patterns.md
@@ -265,11 +265,11 @@ Host fetches the requested contracts (locally first, then network) and re-invoke
 - **Max 10 related contracts per request** (`MAX_RELATED_CONTRACTS_PER_REQUEST`). Cap your state's distinct related references at validation time so you can't produce a state needing more than 10.
 - **10s fetch timeout per request.** Multiple bogus references multiply the latency cost.
 
-### Validate-After-Update Pattern
+### Requesting Related State From `update_state`
 
-`update_state` does **not** currently have a `related` parameter (as of writing). If your auth needs to consult another contract, do it in `validate_state` — the host runs `validate_state` after every successful `update_state` and rolls back on `Invalid`.
+`update_state` takes no `related` parameter, but it is not confined to `validate_state` for cross-contract reads: return `UpdateModification::requires(vec![...])` and the host resolves those contracts — local state store first, network only as fallback — and re-invokes `update_state` with the results supplied as `UpdateData::RelatedState` entries. The host also runs `validate_state` after every successful `update_state` and rolls back on `Invalid`, so validate remains the backstop.
 
-This pattern means `update_state` does cheap checks only (signature, size, format); cross-contract auth happens in the validate pass that the host runs immediately after.
+**Prefer the `update_state` route where either would work.** Related state resolved during *validation* is never captured by the conformance system (freenet-core#5376), so a contract whose validity depends on that path can never be judged — and an unjudgeable contract reads exactly like a clean one. The update path is captured today.
 
 ### Production Track Record
 

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -127,10 +127,10 @@ edition = "2021"
 
 [dependencies]
 # Mirror River's pinned versions; see https://github.com/freenet/river/blob/main/ui/Cargo.toml
-# stdlib bumped to 0.8 to track current freenet-stdlib release.
-dioxus = { version = "0.7.3", features = ["web"] }
+# stdlib 0.8.5 tracks the current freenet-stdlib release.
+dioxus = { version = "0.7.9", features = ["web"] }
 dioxus-free-icons = { version = "0.10.0", features = ["font-awesome-solid"] }
-freenet-stdlib = { version = "0.8", features = ["net"] }
+freenet-stdlib = { version = "0.8.5", features = ["net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 web-sys = { version = "0.3", features = ["WebSocket", "MessageEvent", "Window", "Location"] }
@@ -299,7 +299,7 @@ asynchronously. Wait for the "connected" callback before sending requests.
 The UI crate needs these dependencies for WebSocket to work on `wasm32-unknown-unknown`:
 
 ```toml
-freenet-stdlib = { version = "0.6.0", features = ["net"] }
+freenet-stdlib = { version = "0.8.5", features = ["net"] }
 # Required for wasm32-unknown-unknown: use JS crypto.getRandomValues for RNG
 getrandom = { version = "0.2", features = ["js", "wasm-bindgen", "js-sys"], default-features = false }
 ```


### PR DESCRIPTION
## Problem

The `dapp-builder` skill told readers, under "Advanced Capabilities":

> **Contract Interoperability:** Contracts reading other contracts' state is planned but not yet implemented

That is wrong, and it actively misled a reader today — it steers a dApp author away from a mechanism that exists and works.

## Approach

Verified every replacement claim against `freenet-core` `main` before writing:

- `validate_state` can return `ValidateResult::RequestRelated(Vec<ContractInstanceId>)`, and `fetch_related_for_validation_network` (`crates/core/src/contract/executor/runtime/contract_ops.rs:650`) resolves those ids and re-invokes with `RelatedContracts` populated — reached from `perform_contract_put` (:69) and from `get_updated_state` (:297) on the UPDATE path.
- The machinery is real, not a stub: `MAX_INFLIGHT_DEFERRALS = 256` (`contract.rs:100`), an RAII `ResumeGuard` (`contract.rs:162`, `Drop` at :226) documented as giving exactly-once resume, and over-cap ops surfacing `MissingRelated` instead of growing unboundedly (`contract.rs:1696-1705`). freenet-core#4391.
- freenet-core#2870 is still OPEN but is itself partly stale: the UPDATE-path `todo!()` it cites at `runtime.rs:946` no longer exists — there is no `todo!` anywhere in that 2,943-line file.

**The important addition is the constraint, not the capability.** A contract's verdict must be a function of its inputs or replicas diverge, so the skill now says: reading an immutable fact is safe, reading a monotonic fact in the once-true-always-true direction is safe, and gating validity on mutable or growing state is not — "reject if the other party has more than N entries" flips as their state grows, so peers validating at different moments never converge. That class of rule belongs in client-side policy.

Plus the practical limits: one round only (`contract_ops.rs:431-432`, capped at `MAX_RELATED_CONTRACTS_PER_REQUEST = 10`, `runtime.rs:19`); `RelatedStateAndDelta` is the client-submittable UPDATE form while bare `RelatedState`/`RelatedDelta` are rejected from `ContractRequest::Update` (`contract.rs:2444-2457`); freenet-core#4077 (open, a related fetch that times out can wedge an UPDATE merge); freenet-core#5376 (open, validation-resolved related state is never captured by conformance, so such a contract is unjudgeable and reads exactly like a clean one); and freenet-scaffold's `#[composable]` having no inter-contract awareness (freenet-core#2870).

### Two stale version claims found while checking the above

- "As of May 2026 — River pins `freenet-stdlib = "0.6.0"` but the upstream crate is now `0.8`" is out of date in both halves. River's workspace `Cargo.toml:64` pins `0.8.5`, which is `max_stable_version` on crates.io, so the reference dApp and upstream no longer diverge. The "track this against stdlib 0.8 once River bumps" conditional is dropped.
- The security section attributed the `DEFAULT_CIPHER` / `DEFAULT_NONCE` removal to stdlib **v0.6.0**. Both constants are present in the published 0.6.0 and 0.6.1 sources and absent from 0.8.0; freenet-stdlib PR #75 merged 2026-05-16T18:00:33Z and 0.8.0 was published 18:04:31Z the same day. Corrected to **0.8.0**, and the upgrade step is now written as 0.6 → 0.8 because no 0.7 was ever published to crates.io.

## Testing

Documentation-only. No behavioral code in this repo. Every factual claim above was verified against checked-out source, the published crate sources, or the GitHub API for the cited issue/PR — none is carried over on trust. `marketplace.json` bumped to 1.29.0 and `CHANGELOG.md` updated, per the repo's version-check workflow.

[AI-assisted - Claude]

https://claude.ai/code/session_01Nq78BB4W6t1NBwPKoa9Giu
