### PR TITLE
docs(dapp-builder): what a delegate can actually do with contracts, and what limits it (v1.30.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.29.0"
+    "version": "1.30.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.30.0 (2026-08-30)
+
+Corrects what `dapp-builder` says a delegate can do with contracts, and adds the
+resource limits it never documented. Verified against freenet-core `main` @
+`b863ee7c6` and freenet-stdlib `main` @ `99ee584`.
+
+The dangerous claim was in `references/delegate-patterns.md`: a delegate that
+subscribes to a contract "is woken by `InboundDelegateMsg::ContractNotification`
+whenever that contract's state changes, with no UI open". Notification delivery
+does work, but `send_delegate_contract_notifications`
+(`crates/core/src/contract/executor/runtime/executor_impl.rs:2168`) fires on any
+*local* state commit, so a write that happened elsewhere reaches the delegate only
+if the node is subscribed to that contract by some other route. In practice that
+route is the app's own UI WebSocket, which goes away when the tab closes, so the
+background-service pattern stops working at exactly the moment it was supposed to
+earn its keep. That is the failure freenet/delta#30 hit. Delivery is also
+best-effort: a `try_send` on a bounded channel, dropped when full.
+
+- **"Read, write, and subscribe to contracts" moved out of "implemented and
+  usable today" into a new "implemented, but local to this node" section**, with
+  a per-verb table and the evidence for each. A delegate GET is gated on
+  `lookup_key` resolving locally (`crates/core/src/contract.rs:758`) and bottoms
+  out in `perform_contract_get` (`executor_impl.rs:1431`), a bare
+  `state_store.get(&key)`; the V2 error code says so in words,
+  `ERR_CONTRACT_NOT_FOUND (-7): contract not in local store`. A delegate PUT
+  calls `upsert_contract_state` and emits `NodeEvent::BroadcastStateChange`,
+  which fans out to peers *already* interested, where a client PUT opens a
+  `put::PutMsg` transaction and routes toward the key
+  (`crates/core/src/client_events.rs:519`). A delegate subscribe only inserts
+  into `DELEGATE_SUBSCRIPTIONS` (`wasm_runtime/native_api.rs:40`); nothing in
+  `ring/` reads it and `contract_in_use` (`ring/hosting.rs:1725`) has no delegate
+  term, so it sets no demand, enters no renewal, and exempts nothing from
+  eviction. Fixes are in progress under freenet-core#4669 and the
+  freenet-core#5467 epic, and the text says so rather than describing them as
+  done.
+- **"Creating other delegates from within a delegate" is no longer listed as
+  unimplemented.** The old reasoning was that no such variant exists on
+  `OutboundDelegateMsg`. The variant genuinely does not exist and the capability
+  is a host function, `DelegateCtx::create_delegate` (stdlib
+  `rust/src/delegate_host.rs:642`), registered in the
+  `freenet_delegate_management` namespace at
+  `crates/core/src/wasm_runtime/engine/wasmtime_engine.rs:2117`.
+- **Both message-enum listings were pre-v0.5 and simply wrong.** They showed
+  `GetSecretRequest` / `GetSecretResponse` / `SetSecretRequest` as variants, none
+  of which exist any more, and omitted every contract variant. Replaced with the
+  real definitions from `freenet-stdlib/rust/src/delegate_interface.rs`
+  (inbound `:524`, outbound `:701`), including the asymmetry that matters when
+  writing a delegate: `InboundDelegateMsg` IS `#[non_exhaustive]` so a `match`
+  needs a wildcard arm, while `OutboundDelegateMsg` is NOT, so adding a variant
+  there is a breaking change. The doc comment at `delegate_interface.rs:518`
+  claims otherwise and is wrong; the file now warns about it.
+- **New section on the V2 host-function API**, which was undocumented despite
+  being registered and live: the `freenet_delegate_contracts` namespace
+  (`get_contract_state`, `get_contract_state_len`, `put_contract_state`,
+  `update_contract_state`, `subscribe_contract`), how core detects a V2 module
+  by scanning imports, and the two traps: V2 converges on the same handlers so
+  the local-only limits apply identically, and `update_contract_state` is a full
+  state replacement that does not run the contract's `update_state` merge.
+  Alongside it, the V1 loop's bound, `MAX_CONTRACT_REQUEST_ITERATIONS = 100`,
+  which returns a truncated result rather than an error on overflow
+  (freenet-core#5454).
+- **New "Resource Limits" section.** Epoch interruption is the real preemption
+  guard: a 100 ms global tick with a per-execution deadline derived from
+  `max_execution_seconds` (default 5.0) and `epoch_deadline_trap()`, armed on
+  every guest entry including the V2 delegate one. Memory is capped at 256 MiB
+  by a wasmtime `ResourceLimiter`. **Fuel metering is off by default in
+  production** (`enable_metering = false`), so it is not a live guard and the
+  section says not to reason about cost in terms of it. Child-delegate creation
+  is bounded by depth 4, 8 per call, 1024 per node and a 10 MiB WASM cap; app
+  registrations by `MAX_APPS_PER_DELEGATE = 128`, `MAX_DELEGATES_PER_CLIENT =
+  256` and a 30-minute TTL sweep. The section then names what has no guard: no
+  cross-invocation cost accounting, an unbounded subscription registry
+  (freenet-core#4824), no quarantine or circuit breaker for a delegate that
+  panics every invocation (freenet-core#5467 Phase 4, designed not built), and
+  no per-delegate observability at all (Phase 0) which is why the subscription
+  gap survived so long.
+- **New "What a Delegate Is Not Good For Yet" section**: durable pinning of
+  content, autonomous background work (there is no scheduled wakeup;
+  freenet-core#3972, freenet-stdlib#82 draft, shelved host side in
+  freenet-core#4666), fetching arbitrary contracts from the network, and knowing
+  its own subscriptions after a restart.
+- Smaller corrections in the same file: UPDATE accepts only `UpdateData::State`
+  and `UpdateData::Delta` and rejects every compound and `Related*` variant;
+  subscribe requires the contract to be known locally on both registration
+  paths; there is no explicit unsubscribe, and the `TODO(#2830)` that marks it
+  cites an issue that is now closed. The header note no longer says user
+  permission requests "may have limited support" and the "User Permission
+  Pattern (Limited Support)" heading loses its qualifier: the flow is wired end
+  to end through `DashboardPrompter`
+  (`crates/core/src/contract/user_input.rs:188`, constructed at
+  `node/p2p_impl.rs:950`), which opens the permission page in the browser when
+  no dashboard tab is connected and auto-denies after 60 seconds.
+- `SKILL.md` Phase 2 suggests splitting delegates "per long-running background
+  task", which reads as an endorsement of a capability that is not there yet. It
+  now carries a short caveat pointing at the reference section.
+
 ## 1.29.0 (2026-08-28)
 
 Corrects the `dapp-builder` claim that contracts cannot read each other's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
 - **"Read, write, and subscribe to contracts" moved out of "implemented and
   usable today" into a new "implemented, but local to this node" section**, with
   a per-verb table and the evidence for each. A delegate GET is gated on
-  `lookup_key` resolving locally (`crates/core/src/contract.rs:758`) and bottoms
+  `lookup_key` resolving locally (`crates/core/src/contract.rs:759`) and bottoms
   out in `perform_contract_get` (`executor_impl.rs:1431`), a bare
   `state_store.get(&key)`; the V2 error code says so in words,
   `ERR_CONTRACT_NOT_FOUND (-7): contract not in local store`. A delegate PUT
@@ -48,7 +48,7 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   `GetSecretRequest` / `GetSecretResponse` / `SetSecretRequest` as variants, none
   of which exist any more, and omitted every contract variant. Replaced with the
   real definitions from `freenet-stdlib/rust/src/delegate_interface.rs`
-  (inbound `:524`, outbound `:701`), including the asymmetry that matters when
+  (inbound `:526`, outbound `:701`), including the asymmetry that matters when
   writing a delegate: `InboundDelegateMsg` IS `#[non_exhaustive]` so a `match`
   needs a wildcard arm, while `OutboundDelegateMsg` is NOT, so adding a variant
   there is a breaking change. The doc comment at `delegate_interface.rs:518`
@@ -57,12 +57,46 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   being registered and live: the `freenet_delegate_contracts` namespace
   (`get_contract_state`, `get_contract_state_len`, `put_contract_state`,
   `update_contract_state`, `subscribe_contract`), how core detects a V2 module
-  by scanning imports, and the two traps: V2 converges on the same handlers so
-  the local-only limits apply identically, and `update_contract_state` is a full
-  state replacement that does not run the contract's `update_state` merge.
-  Alongside it, the V1 loop's bound, `MAX_CONTRACT_REQUEST_ITERATIONS = 100`,
-  which returns a truncated result rather than an error on overflow
+  by scanning imports, and the traps. The load-bearing one is that **the two API
+  versions expose the same operations under the same names and do not do the
+  same thing on writes.** V1 PUT and UPDATE go through `upsert_contract_state`
+  into `commit_state_update` (`executor_impl.rs:1996`), which emits
+  `NodeEvent::BroadcastStateChange` and notifies subscribed delegates. V2
+  `put_contract_state` / `update_contract_state` bottom out in
+  `put_contract_state_sync` / `update_contract_state_sync` (`native_api.rs:796`,
+  `:849`), raw ReDb writes whose own comments say they bypass the executor's
+  `state_store.store` call site; there is no broadcast and no delegate
+  notification on that path, so a V2 write lands on local disk and stops. The
+  call returns success and reads back locally, so a single-node test cannot see
+  it. That is freenet-core#5479, open, and the section says to use the V1
+  messages for any write other peers need to see. Also: reads and the subscribe
+  gap do apply to V2 identically, and `update_contract_state` is a full state
+  replacement that does not run the contract's `update_state` merge. Alongside
+  it, the V1 loop's bound, `MAX_CONTRACT_REQUEST_ITERATIONS = 100`, which
+  returns a truncated result rather than an error on overflow
   (freenet-core#5454).
+- **New section on `freenet local`, which does not run the delegate contract
+  loop at all.** `handle_delegate_with_contract_requests`
+  (`crates/core/src/contract.rs:537`) has two call sites, both under
+  `contract_handling` (`:1268`), which is spawned from one production site,
+  `node/p2p_impl.rs:948`, the network node. `run_local_node` (`node.rs:5768`)
+  handles `ClientRequest::DelegateOp` by calling `executor.delegate_request(...)`
+  directly (`:5851`), so a V1 delegate's `GetContractRequest`,
+  `PutContractRequest`, `UpdateContractRequest` and `SubscribeContractRequest`
+  are never serviced and nothing reports an error. freenet-core#5273 records the
+  `RequestUserInput` symptom of the same root cause; the contract verbs are not
+  recorded there. V2 host functions do work locally, because they are wasmtime
+  imports resolved inside the delegate's own execution and
+  `Executor::from_config_local` wires the store behind them
+  (`contract/executor/runtime.rs:366`, `:380`). This matters because an agent
+  building a dApp will reach for `freenet local` first, see nothing happen, and
+  have no way to tell why.
+- **The notification path is narrower than "any local commit".**
+  `send_delegate_contract_notifications` has a single call site, inside
+  `commit_state_update` (`executor_impl.rs:2108`), which is the merge path.
+  Initial-state install and resync-driven applies take a different branch and
+  never reach it (freenet-core#5481), and the V2 write path does not notify at
+  all (freenet-core#5479).
 - **New "Resource Limits" section.** Epoch interruption is the real preemption
   guard: a 100 ms global tick with a per-execution deadline derived from
   `max_execution_seconds` (default 5.0) and `epoch_deadline_trap()`, armed on
@@ -77,7 +111,17 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   (freenet-core#4824), no quarantine or circuit breaker for a delegate that
   panics every invocation (freenet-core#5467 Phase 4, designed not built), and
   no per-delegate observability at all (Phase 0) which is why the subscription
-  gap survived so long.
+  gap survived so long. Two gaps specific to execution, both freenet-core#5480:
+  the epoch trap interrupts guest code only, so a delegate parked inside a host
+  call runs to completion whatever the deadline says
+  (`wasmtime_engine.rs:695-698`); and delegates do not reach
+  `execute_wasm_blocking` (`:2326`, called only from the contract entry points
+  at `:1210` and `:1287`), so they get neither the wall-clock backstop nor the
+  panic capture contracts get. If the epoch ticker thread dies, contracts fall
+  back to the wall-clock poll and delegates fall back to nothing;
+  freenet-core#4864 added a heartbeat because that thread stopping is a real
+  scenario. The section deliberately does not say delegates are unguarded: they
+  are guarded per invocation, and the gaps are specific.
 - **New "What a Delegate Is Not Good For Yet" section**: durable pinning of
   content, autonomous background work (there is no scheduled wakeup;
   freenet-core#3972, freenet-stdlib#82 draft, shelved host side in
@@ -96,7 +140,9 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   no dashboard tab is connected and auto-denies after 60 seconds.
 - `SKILL.md` Phase 2 suggests splitting delegates "per long-running background
   task", which reads as an endorsement of a capability that is not there yet. It
-  now carries a short caveat pointing at the reference section.
+  now carries a short caveat pointing at the reference section, and that caveat
+  also says to test delegate contract access against a real node rather than
+  `freenet local`.
 
 ## 1.29.0 (2026-08-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   into `DELEGATE_SUBSCRIPTIONS` (`wasm_runtime/native_api.rs:40`); nothing in
   `ring/` reads it and `contract_in_use` (`ring/hosting.rs:1725`) has no delegate
   term, so it sets no demand, enters no renewal, and exempts nothing from
-  eviction. Fixes are in progress under freenet-core#4669 and the
-  freenet-core#5467 epic, and the text says so rather than describing them as
-  done.
+  eviction. Both gaps are open under freenet-core#4669 and the freenet-core#5467
+  epic with no fix merged as of 2026-08-30, and the text says so rather than
+  describing a fix as done or as imminent.
 - **"Creating other delegates from within a delegate" is no longer listed as
   unimplemented.** The old reasoning was that no such variant exists on
   `OutboundDelegateMsg`. The variant genuinely does not exist and the capability
@@ -51,8 +51,9 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   (inbound `:526`, outbound `:701`), including the asymmetry that matters when
   writing a delegate: `InboundDelegateMsg` IS `#[non_exhaustive]` so a `match`
   needs a wildcard arm, while `OutboundDelegateMsg` is NOT, so adding a variant
-  there is a breaking change. The doc comment at `delegate_interface.rs:518`
-  claims otherwise and is wrong; the file now warns about it.
+  there is a breaking change. The doc comment at `delegate_interface.rs:518-519`
+  claims otherwise and is wrong; the file now warns about it, and tells the
+  reader to check the attribute in the stdlib version they build against.
 - **New section on the V2 host-function API**, which was undocumented despite
   being registered and live: the `freenet_delegate_contracts` namespace
   (`get_contract_state`, `get_contract_state_len`, `put_contract_state`,
@@ -64,8 +65,9 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   `NodeEvent::BroadcastStateChange` and notifies subscribed delegates. V2
   `put_contract_state` / `update_contract_state` bottom out in
   `put_contract_state_sync` / `update_contract_state_sync` (`native_api.rs:796`,
-  `:849`), raw ReDb writes whose own comments say they bypass the executor's
-  `state_store.store` call site; there is no broadcast and no delegate
+  `:849`), raw ReDb writes whose own comment says "the V2 path bypasses the
+  executor `state_store` chokepoint" (`native_api.rs:814-816`); there is no
+  broadcast and no delegate
   notification on that path, so a V2 write lands on local disk and stops. The
   call returns success and reads back locally, so a single-node test cannot see
   it. That is freenet-core#5479, open, and the section says to use the V1
@@ -85,12 +87,17 @@ best-effort: a `try_send` on a bounded channel, dropped when full.
   `PutContractRequest`, `UpdateContractRequest` and `SubscribeContractRequest`
   are never serviced and nothing reports an error. freenet-core#5273 records the
   `RequestUserInput` symptom of the same root cause; the contract verbs are not
-  recorded there. V2 host functions do work locally, because they are wasmtime
-  imports resolved inside the delegate's own execution and
+  recorded there. Three of the V2 host functions do work locally, because they
+  are wasmtime imports resolved inside the delegate's own execution and
   `Executor::from_config_local` wires the store behind them
-  (`contract/executor/runtime.rs:366`, `:380`). This matters because an agent
-  building a dApp will reach for `freenet local` first, see nothing happen, and
-  have no way to tell why.
+  (`contract/executor/runtime.rs:366`, `:380`): `get_contract_state`,
+  `put_contract_state` and `update_contract_state` all hit the local store.
+  `subscribe_contract` is the exception, and notification delivery is dead
+  locally for both API versions, because `delegate_notification_tx` is set only
+  by `RuntimePool` (`pool.rs:538`) and `freenet local` builds a plain `Executor`
+  (`bin/freenet.rs:183`) that leaves it `None` (`contract/executor.rs:1685`).
+  This matters because an agent building a dApp will reach for `freenet local`
+  first, see nothing happen, and have no way to tell why.
 - **The notification path is narrower than "any local commit".**
   `send_delegate_contract_notifications` has a single call site, inside
   `commit_state_update` (`executor_impl.rs:2108`), which is the merge path.

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -262,7 +262,8 @@ Determine what private data each user needs stored locally and split it across d
 > delegate runs only when something pokes it: there is no scheduled wakeup
 > (freenet-core#3972). Its contract GET reads the local store only, and its
 > contract subscribe registers no network demand, so subscribing does not keep a
-> contract alive in the network (freenet-core#4669). Both are being worked on.
+> contract alive in the network (freenet-core#4669). Both are open with no fix
+> merged as of 2026-08-30.
 > Test that work against a real node: `freenet local` never runs the loop that
 > services a delegate's contract requests, so a delegate's GET, PUT, UPDATE and
 > SUBSCRIBE all silently do nothing there (freenet-core#5273).

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -263,6 +263,9 @@ Determine what private data each user needs stored locally and split it across d
 > (freenet-core#3972). Its contract GET reads the local store only, and its
 > contract subscribe registers no network demand, so subscribing does not keep a
 > contract alive in the network (freenet-core#4669). Both are being worked on.
+> Test that work against a real node: `freenet local` never runs the loop that
+> services a delegate's contract requests, so a delegate's GET, PUT, UPDATE and
+> SUBSCRIBE all silently do nothing there (freenet-core#5273).
 > `references/delegate-patterns.md` → "Delegate Capabilities" has the verified
 > detail and the current state.
 

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -258,6 +258,14 @@ References:
 
 Determine what private data each user needs stored locally and split it across delegates by responsibility (e.g. one delegate per trust boundary or per long-running background task). Most apps need at least one delegate; many need several.
 
+> **Know the limits before you lean on a delegate for background work.** A
+> delegate runs only when something pokes it: there is no scheduled wakeup
+> (freenet-core#3972). Its contract GET reads the local store only, and its
+> contract subscribe registers no network demand, so subscribing does not keep a
+> contract alive in the network (freenet-core#4669). Both are being worked on.
+> `references/delegate-patterns.md` → "Delegate Capabilities" has the verified
+> detail and the current state.
+
 **Key questions (per delegate):**
 - What user-specific data needs persistence? (keys, preferences, cached data)
 - What signing/encryption operations are needed?

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -59,6 +59,10 @@ subscribe to contracts, and every one of those handlers runs. What none of them
 do is reach the network the way the equivalent client request does. Verified
 against freenet-core `main` @ `b863ee7c6`:
 
+The table is the V1 (`OutboundDelegateMsg`) path. The V2 host functions are
+worse for writes, not equivalent; see
+[V2 Host Functions](#v2-host-functions-direct-contract-access).
+
 | Verb | Local | Network |
 |---|---|---|
 | `GetContractRequest` | reads the local state store | nothing. No GET operation is started |
@@ -68,26 +72,33 @@ against freenet-core `main` @ `b863ee7c6`:
 
 - **A delegate GET only sees contracts this node already holds.** The handler is
   gated on `executor().lookup_key(&contract_id)` resolving locally
-  (`crates/core/src/contract.rs:758`), and when it does resolve the fetch bottoms
+  (`crates/core/src/contract.rs:759`), and when it does resolve the fetch bottoms
   out in `perform_contract_get`
-  (`crates/core/src/contract/executor/runtime/executor_impl.rs:1431`), which is a
-  `state_store.get(&key)` and nothing else. The delegate gets `None` for anything
-  the node does not hold. The V2 error code says the same thing in words:
+  (`crates/core/src/contract/executor/runtime/executor_impl.rs:1431`), which reads
+  the local state store and, when the code is asked for, the local contract store.
+  Neither touches the network. The delegate gets `None` for anything the node does
+  not hold. The V2 error code says the same thing in words:
   `ERR_CONTRACT_NOT_FOUND (-7): contract not in local store`
-  (`crates/core/src/wasm_runtime/native_api.rs:1734`). A fix is in progress under
-  the freenet-core#5467 epic; re-check this before relying on either behaviour.
+  (`crates/core/src/wasm_runtime/native_api.rs:1734`). As of 2026-08-30 the read
+  path has no tracking issue of its own, so do not assume it is about to change.
 - **A delegate PUT is not a client PUT.** It calls `upsert_contract_state`
-  (`contract.rs:714`), which stores locally and emits
+  (`contract.rs:716`), which stores locally and emits
   `NodeEvent::BroadcastStateChange` (`crates/core/src/message.rs:953`), fanning
   the new state out to peers that are *already* interested in the contract. A
   client PUT instead opens a `put::PutMsg` transaction and routes toward the key
   (`crates/core/src/client_events.rs:519`, whose own comment reads "finds peers,
-  sends the request"). A delegate PUT of a contract nobody is yet interested in
-  therefore lands on this node and nowhere else.
+  sends the request"). The missing piece is placement: no request is routed
+  toward the key, so nothing puts the contract anywhere near where a later GET
+  will look for it. A broadcast that finds no targets is not simply dropped, it
+  retries with backoff and is stashed for re-emission when an interested peer
+  appears (`crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs:179`),
+  and the periodic InterestSync anti-entropy heals from the other direction. So
+  the state can still reach peers that later take an interest. It will not become
+  findable by key.
 - **A delegate UPDATE takes only `UpdateData::State` and `UpdateData::Delta`.**
   `StateAndDelta` and every `Related*` variant are rejected with
   `Err("Unsupported UpdateData variant")`, because the delegate API has no way to
-  supply the related-contract context (`contract.rs:820-855`). UPDATE also needs
+  supply the related-contract context (`contract.rs:822-856`). UPDATE also needs
   the contract to resolve locally and returns `Err("Contract not found")`
   otherwise.
 - **A delegate subscription registers no network demand.** It inserts into
@@ -98,11 +109,15 @@ against freenet-core `main` @ `b863ee7c6`:
   `has_client_subscriptions(..) || has_downstream_subscribers(..)` with no
   delegate term. So a delegate subscribe does not set `contract_in_use`, does not
   enter `contracts_needing_renewal()`, and does not exempt the contract from
-  eviction. This is freenet-core#4669, Phase 1 of the freenet-core#5467 epic,
-  open with the design signed off, and a fix is in progress.
+  eviction. This is freenet-core#4669, Phase 1 of the freenet-core#5467 epic. It
+  is open, its design is signed off in the issue, and it is being worked on as of
+  2026-08-30. Nothing has landed; treat the behaviour above as current until you
+  have checked `contract_in_use` yourself.
 - **Subscribing also requires the contract to be known locally.** Both
-  registration paths validate with `lookup_key` before inserting: V1 at
-  `contract.rs:929`, V2 at `native_api.rs:901`.
+  registration paths validate before inserting, under different names: V1 calls
+  `lookup_key` (`contract.rs:929`), V2 calls `resolve_contract_key`
+  (`native_api.rs:906`, defined at `:747`), which resolves through the contract
+  store's index. Grepping for `lookup_key` in `native_api.rs` finds nothing.
 - **There is no explicit unsubscribe.** `contract.rs:915` carries
   `TODO(#2830): UnsubscribeContractRequest is not yet handled`. That issue is
   closed and the remaining gap is tracked under freenet-core#5467 Phase 1. Today
@@ -112,14 +127,21 @@ against freenet-core `main` @ `b863ee7c6`:
 subscribed delegate "is woken by `InboundDelegateMsg::ContractNotification`
 whenever that contract's state changes, with no UI open". Two things are wrong
 with that. `send_delegate_contract_notifications` (`executor_impl.rs:2168`) fires
-on any *local* state commit, so the delegate is woken only when this node's copy
+on a *local* state commit, so the delegate is woken only when this node's copy
 changes. For a write that happened elsewhere, that means the node has to be
 subscribed to the contract by some other route, and in practice the other route
 is the app's own UI WebSocket, which goes away when the tab closes. The pattern
 stops working at exactly the moment it was supposed to earn its keep. That is the
-failure freenet/delta#30 hit. Delivery is also best-effort: the notification is a
-`try_send` on a bounded channel and is dropped when the channel is full
-(`executor_impl.rs:2196`), so a delegate that needs certainty has to poll the
+failure freenet/delta#30 hit.
+
+Delivery is narrower than "any local commit", in two ways. The function has a
+single call site, inside `commit_state_update` (`executor_impl.rs:2108`), which
+is the merge path. Initial-state install and resync-driven applies take a
+different branch and never reach it, so a subscribed delegate misses those
+(freenet-core#5481), and the V2 write path does not notify at all
+(freenet-core#5479). What does reach the function is then best-effort: a
+`try_send` on a bounded channel, dropped when the channel is full
+(`executor_impl.rs:2194`). A delegate that needs certainty has to poll the
 contract state as well.
 
 ## What a Delegate Is Not Good For Yet
@@ -185,7 +207,9 @@ exist in either enum; secrets are `DelegateCtx` methods now.
 
 Wire format is bincode, with the variant index taken from declaration order, so
 reordering either enum is a wire break. `inbound_delegate_msg_wire_format_is_stable`
-pins the inbound tags.
+(stdlib `delegate_interface.rs:1238`) pins only the FIRST inbound variant,
+`ApplicationMessage`, at tag 0. Reordering the variants after it would not fail
+that test, so do not rely on CI to catch it.
 
 One trap when reading the source: the doc comment above `InboundDelegateMsg`
 (`delegate_interface.rs:518`) says its `#[non_exhaustive]` "matches the
@@ -199,9 +223,9 @@ There are two live delegate API versions, and a delegate may use either.
 **V1, request and response.** `process()` returns e.g.
 `OutboundDelegateMsg::GetContractRequest`; the host handles it and re-invokes
 `process()` with `GetContractResponse`. Continuation state rides in
-`DelegateContext`. The loop is at `crates/core/src/contract.rs:590` and is
+`DelegateContext`. The loop is at `crates/core/src/contract.rs:591` and is
 bounded by `MAX_CONTRACT_REQUEST_ITERATIONS = 100` (`contract.rs:60`). On
-overflow it returns whatever it accumulated so far (`contract.rs:598`) rather
+overflow it returns whatever it accumulated so far (`contract.rs:600`) rather
 than erroring, so a delegate that exceeds the bound sees a truncated result and
 no failure signal. Whether that should be an error is freenet-core#5454.
 
@@ -216,18 +240,30 @@ ctx.subscribe_contract(&instance_id)                      // -> bool
 ctx.create_delegate(wasm, params, cipher, nonce)          // -> Result<([u8; 32], [u8; 32]), i32>
 ```
 
-The first four import from the `freenet_delegate_contracts` namespace and
+`get_contract_state_len` is the paired length query the two-step read protocol
+uses. The first five import from the `freenet_delegate_contracts` namespace and
 `create_delegate` from `freenet_delegate_management`. Both are registered in the
 wasmtime linker (`wasmtime_engine.rs:2035` and `:2117`), and core decides a
 module is V2 by scanning its imports (`wasmtime_engine.rs:923`). The
 implementations are in `crates/core/src/wasm_runtime/native_api.rs`.
 
-Two things to know before reaching for V2:
+Three things to know before reaching for V2:
 
-- **The local-only limits above apply identically.** Both API versions converge
-  on the same handlers, and V2's `subscribe_contract` writes to the same
-  `DELEGATE_SUBSCRIPTIONS` registry. V2 changes the calling convention, not what
-  reaches the network.
+- **V2 writes reach the network LESS than V1 writes, not the same amount.** V1
+  PUT and UPDATE go through `upsert_contract_state` into `commit_state_update`
+  (`executor_impl.rs:1996`), which emits `NodeEvent::BroadcastStateChange` and
+  notifies subscribed delegates. V2 `put_contract_state` and
+  `update_contract_state` bottom out in `put_contract_state_sync` /
+  `update_contract_state_sync` (`native_api.rs:796` and `:849`), which write to
+  ReDb directly. Their own comments say the path "bypasses the executor's
+  `state_store.store` call site". There is no broadcast and no delegate
+  notification on that path at all, so a V2 write lands on local disk and stops.
+  This is freenet-core#5479, open. Until it is fixed, use the V1
+  `PutContractRequest` / `UpdateContractRequest` messages for any write whose
+  result other peers need to see.
+- **The local-only reads and the subscribe gap apply to V2 as well.**
+  `subscribe_contract` writes to the same `DELEGATE_SUBSCRIPTIONS` registry, and
+  `get_contract_state` reads the same local store.
 - **`update_contract_state` is a full state replacement.** It does not run the
   contract's `update_state` merge logic, and it fails if there is no prior state
   (stdlib `delegate_host.rs:573-580`).

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -59,8 +59,8 @@ subscribe to contracts, and every one of those handlers runs. What none of them
 do is reach the network the way the equivalent client request does. Verified
 against freenet-core `main` @ `b863ee7c6`:
 
-The table is the V1 (`OutboundDelegateMsg`) path. The V2 host functions are
-worse for writes, not equivalent; see
+The table covers the V1 (`OutboundDelegateMsg`) path. V2 writes reach the
+network even less than these; see
 [V2 Host Functions](#v2-host-functions-direct-contract-access).
 
 | Verb | Local | Network |
@@ -91,7 +91,7 @@ worse for writes, not equivalent; see
   toward the key, so nothing puts the contract anywhere near where a later GET
   will look for it. A broadcast that finds no targets is not simply dropped, it
   retries with backoff and is stashed for re-emission when an interested peer
-  appears (`crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs:179`),
+  appears (`crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs:178`),
   and the periodic InterestSync anti-entropy heals from the other direction. So
   the state can still reach peers that later take an interest. It will not become
   findable by key.
@@ -115,7 +115,7 @@ worse for writes, not equivalent; see
   have checked `contract_in_use` yourself.
 - **Subscribing also requires the contract to be known locally.** Both
   registration paths validate before inserting, under different names: V1 calls
-  `lookup_key` (`contract.rs:929`), V2 calls `resolve_contract_key`
+  `lookup_key` (`contract.rs:932`), V2 calls `resolve_contract_key`
   (`native_api.rs:906`, defined at `:747`), which resolves through the contract
   store's index. Grepping for `lookup_key` in `native_api.rs` finds nothing.
 - **There is no explicit unsubscribe.** `contract.rs:915` carries
@@ -144,6 +144,42 @@ different branch and never reach it, so a subscribed delegate misses those
 (`executor_impl.rs:2194`). A delegate that needs certainty has to poll the
 contract state as well.
 
+## `freenet local` Does Not Run the Delegate Contract Loop
+
+Everything above describes a node attached to the network. Under `freenet local`
+the V1 contract verbs are not serviced at all. A delegate that returns
+`GetContractRequest`, `PutContractRequest`, `UpdateContractRequest` or
+`SubscribeContractRequest` gets no response, writes no state and registers no
+subscription, and nothing reports an error.
+
+The handler for those messages is `handle_delegate_with_contract_requests`
+(`crates/core/src/contract.rs:537`). Both of its call sites sit under
+`contract_handling` (`contract.rs:1268`): the client-driven run at
+`contract.rs:2554` and the contract-notification-driven run at `:2114`.
+`contract_handling` is spawned from one production site,
+`crates/core/src/node/p2p_impl.rs:948`, which is the network node.
+`run_local_node` (`crates/core/src/node.rs:5768`) instead handles
+`ClientRequest::DelegateOp` by calling `executor.delegate_request(...)` straight
+through (`node.rs:5851`), which runs `process()` and hands back its outbound
+messages without acting on any of them.
+
+`RequestUserInput` disappears the same way, and that symptom has its own issue,
+freenet-core#5273. The contract verbs share the root cause and are not recorded
+there.
+
+The V2 host functions behave differently, because they are wasmtime imports
+resolved inside the delegate's own execution rather than messages the node
+services afterwards. `Executor::from_config_local` delegates to `from_config`
+(`crates/core/src/contract/executor/runtime.rs:366`), which wires the state store
+those imports read and write (`:380`). So `ctx.get_contract_state` and
+`ctx.put_contract_state` do run under `freenet local`, against the local store.
+
+**The rule that falls out:** test a delegate's contract access against a real
+node. A V1 delegate that works on the network does nothing under `freenet local`,
+and a V2 delegate that works under `freenet local` is exactly the case the rest
+of the network cannot see (freenet-core#5479, below). Neither mode on its own
+tells you what the other does.
+
 ## What a Delegate Is Not Good For Yet
 
 - **Keeping a user's content alive in the network.** Pinning content by
@@ -163,7 +199,8 @@ contract state as well.
 ## Message Types
 
 Both enums live in freenet-stdlib `rust/src/delegate_interface.rs`, inbound at
-`:524` and outbound at `:701`.
+`:526` and outbound at `:701`. Checked against stdlib `main` @ `99ee584` on
+2026-08-30.
 
 ### Inbound Messages
 
@@ -212,9 +249,15 @@ reordering either enum is a wire break. `inbound_delegate_msg_wire_format_is_sta
 that test, so do not rely on CI to catch it.
 
 One trap when reading the source: the doc comment above `InboundDelegateMsg`
-(`delegate_interface.rs:518`) says its `#[non_exhaustive]` "matches the
+(`delegate_interface.rs:517-518`) says its `#[non_exhaustive]` "matches the
 pre-existing `#[non_exhaustive]` on `OutboundDelegateMsg`". `OutboundDelegateMsg`
 does not carry that attribute. Trust the attribute, not the comment.
+
+The asymmetry is a wart rather than a design, so it may be closed. If a later
+stdlib marks `OutboundDelegateMsg` `#[non_exhaustive]` too, an exhaustive match
+on it stops compiling and a wildcard arm becomes required on both sides. Check
+the attribute in the stdlib version you build against rather than trusting the
+listings here.
 
 ## V2 Host Functions: Direct Contract Access
 
@@ -247,7 +290,13 @@ wasmtime linker (`wasmtime_engine.rs:2035` and `:2117`), and core decides a
 module is V2 by scanning its imports (`wasmtime_engine.rs:923`). The
 implementations are in `crates/core/src/wasm_runtime/native_api.rs`.
 
-Three things to know before reaching for V2:
+**Before choosing between them: the two versions expose the same operations
+under the same names and do not do the same thing.** `get_contract_state`,
+`put_contract_state`, `update_contract_state` and `subscribe_contract` read as
+the V2 spellings of the four `OutboundDelegateMsg` variants, and nothing at the
+call site says otherwise. On writes they diverge, and the V2 call still returns
+success and still reads back locally, so a single-node test cannot tell them
+apart. Three things to know:
 
 - **V2 writes reach the network LESS than V1 writes, not the same amount.** V1
   PUT and UPDATE go through `upsert_contract_state` into `commit_state_update`
@@ -273,16 +322,16 @@ Three things to know before reaching for V2:
 A delegate is not unguarded. The guard that matters is per-invocation
 preemption, and it is not fuel.
 
-- **Wall-clock preemption.** `max_execution_seconds` defaults to 5.0
+- **Epoch preemption.** `max_execution_seconds` defaults to 5.0
   (`crates/core/src/wasm_runtime/runtime.rs:742`), enforced by wasmtime epoch
   interruption. A background thread bumps the epoch every
   `EPOCH_TICK_PERIOD = 100ms` (`wasmtime_engine.rs:453`), and every guest entry
   arms a deadline of `ceil(max_execution_seconds / tick) + 1` ticks
   (`epoch_deadline_ticks`, `:679`) with `epoch_deadline_trap()`, which kills a
-  runaway guest rather than pausing it. The V2 delegate entry point
-  (`call_3i64_async_imports`, `:1132`) arms it like every other, and a
-  source-scrape test asserts that every guest entry does. Note it interrupts
-  guest code only: a host call already in flight runs to completion.
+  runaway guest rather than pausing it. Both delegate entry points arm it (V1
+  `call_3i64` at `:1105`, V2 `call_3i64_async_imports` at `:1132`), and the
+  source-scrape test `every_guest_entry_is_preceded_by_arm_epoch_deadline`
+  (`:2812`) asserts every guest entry does.
 - **Memory** is capped at `DEFAULT_MAX_MEMORY_PAGES` (256 MiB) by a wasmtime
   `ResourceLimiter` installed on the store (`wasmtime_engine.rs:841`).
 - **Fuel metering is off in production.** `enable_metering` defaults to `false`
@@ -300,6 +349,24 @@ What has no guard today, so do not design as though it did:
 
 - **No cross-invocation cost accounting.** Every limit above bounds one call.
   Nothing bounds a delegate that makes many cheap calls indefinitely.
+- **The epoch trap only interrupts guest code.** Wasmtime's epoch checks sit at
+  wasm loop backedges and function entries, so a blocking host call in flight is
+  never cut off; the trap fires only once control returns to guest code
+  (`wasmtime_engine.rs:695-698`). A delegate parked inside a host function (a
+  redb read, a secret-store write) runs to completion whatever the deadline
+  says. V2 has the larger host-function surface, so this grows with the API.
+- **Delegates do not get the wall-clock backstop or the panic capture contracts
+  get.** Contract entry points run through `execute_wasm_blocking`
+  (`wasmtime_engine.rs:2326`, called at `:1210` and `:1287`), which runs the
+  guest on a blocking thread, aborts it on a wall-clock timeout, and converts a
+  Rust panic into a result. Delegate entry points call `block_on_async` on the
+  calling thread and reach none of that, so epoch interruption is their only
+  preemption. If the epoch ticker thread dies there is nothing underneath it;
+  contracts fall back to the wall-clock poll and delegates fall back to nothing.
+  That thread stopping is a real enough scenario that freenet-core#4864 added a
+  heartbeat to detect it. This is freenet-core#5480, open. Keep the panic half
+  in scope: a WASM trap is already an `Err` rather than a panic, so it bites on
+  host-function bugs rather than on any misbehaving delegate.
 - **`DELEGATE_SUBSCRIPTIONS` is unbounded.** One delegate may hold unlimited
   subscriptions, subject only to each contract being known locally. That the
   registry is a process-global rather than per-node state is itself a known

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -5,8 +5,9 @@ Delegates are WebAssembly agents that run locally on the user's device within fr
 > **Note:** This document focuses on patterns used in River. Read
 > [Delegate Capabilities](#delegate-capabilities) before designing around
 > contract access or background work. Several delegate verbs exist and their
-> handlers run, but stay local to this node, and the difference decides whether
-> an app works once the browser tab closes.
+> handlers run, and none of them reaches the network the way the client request
+> of the same name does. That difference decides whether an app works once the
+> browser tab closes.
 
 ## DelegateInterface Trait
 
@@ -35,7 +36,7 @@ impl DelegateInterface for MyDelegate {
 **Implemented and usable today:**
 - Store private data on behalf of users (secrets, keys, preferences) through
   `DelegateCtx::get_secret` / `set_secret` / `has_secret` / `remove_secret` /
-  `list_secrets` (freenet-stdlib `rust/src/delegate_host.rs:344-466`)
+  `list_secrets` (freenet-stdlib `rust/src/delegate_host.rs:365-466`)
 - Send/receive messages from UIs, and from *other apps* on the same node
 - Perform cryptographic operations (signing, encryption)
 - **Request user permission** via `OutboundDelegateMsg::RequestUserInput`. The
@@ -54,10 +55,11 @@ impl DelegateInterface for MyDelegate {
   exist and the capability is a host function rather than an outbound message,
   so its absence proved nothing.
 
-**Implemented, but local to this node.** A delegate can read, write and
-subscribe to contracts, and every one of those handlers runs. What none of them
-do is reach the network the way the equivalent client request does. Verified
-against freenet-core `main` @ `b863ee7c6`:
+**Implemented, and none of it reaches the network the way a client request
+does.** A delegate can read, write and subscribe to contracts, and every one of
+those handlers runs. GET and SUBSCRIBE stay entirely local; PUT and UPDATE store
+locally and broadcast to peers that are already interested, without the routing a
+client PUT performs. Verified against freenet-core `main` @ `b863ee7c6`:
 
 The table covers the V1 (`OutboundDelegateMsg`) path. V2 writes reach the
 network even less than these; see
@@ -80,7 +82,7 @@ network even less than these; see
   not hold. The V2 error code says the same thing in words:
   `ERR_CONTRACT_NOT_FOUND (-7): contract not in local store`
   (`crates/core/src/wasm_runtime/native_api.rs:1734`). As of 2026-08-30 the read
-  path has no tracking issue of its own, so do not assume it is about to change.
+  path has no tracking issue of its own, so do not expect it to change soon.
 - **A delegate PUT is not a client PUT.** It calls `upsert_contract_state`
   (`contract.rs:716`), which stores locally and emits
   `NodeEvent::BroadcastStateChange` (`crates/core/src/message.rs:953`), fanning
@@ -89,16 +91,15 @@ network even less than these; see
   (`crates/core/src/client_events.rs:519`, whose own comment reads "finds peers,
   sends the request"). The missing piece is placement: no request is routed
   toward the key, so nothing puts the contract anywhere near where a later GET
-  will look for it. A broadcast that finds no targets is not simply dropped, it
-  retries with backoff and is stashed for re-emission when an interested peer
-  appears (`crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs:178`),
+  will look for it. A broadcast that finds no targets retries with backoff and
+  is stashed for re-emission when an interested peer appears (`crates/core/src/node/network_bridge/p2p_protoc/broadcast.rs:179`),
   and the periodic InterestSync anti-entropy heals from the other direction. So
   the state can still reach peers that later take an interest. It will not become
   findable by key.
 - **A delegate UPDATE takes only `UpdateData::State` and `UpdateData::Delta`.**
   `StateAndDelta` and every `Related*` variant are rejected with
   `Err("Unsupported UpdateData variant")`, because the delegate API has no way to
-  supply the related-contract context (`contract.rs:822-856`). UPDATE also needs
+  supply the related-contract context (`contract.rs:840-855`). UPDATE also needs
   the contract to resolve locally and returns `Err("Contract not found")`
   otherwise.
 - **A delegate subscription registers no network demand.** It inserts into
@@ -109,13 +110,13 @@ network even less than these; see
   `has_client_subscriptions(..) || has_downstream_subscribers(..)` with no
   delegate term. So a delegate subscribe does not set `contract_in_use`, does not
   enter `contracts_needing_renewal()`, and does not exempt the contract from
-  eviction. This is freenet-core#4669, Phase 1 of the freenet-core#5467 epic. It
-  is open, its design is signed off in the issue, and it is being worked on as of
-  2026-08-30. Nothing has landed; treat the behaviour above as current until you
-  have checked `contract_in_use` yourself.
+  eviction. This is freenet-core#4669, Phase 1 of the freenet-core#5467 epic. As
+  of 2026-08-30 it is open with its design signed off in the issue, and no PR is
+  linked to it. Nothing has landed; treat the behaviour above as current until
+  you have checked `contract_in_use` yourself.
 - **Subscribing also requires the contract to be known locally.** Both
   registration paths validate before inserting, under different names: V1 calls
-  `lookup_key` (`contract.rs:932`), V2 calls `resolve_contract_key`
+  `lookup_key` (`contract.rs:931`), V2 calls `resolve_contract_key`
   (`native_api.rs:906`, defined at `:747`), which resolves through the contract
   store's index. Grepping for `lookup_key` in `native_api.rs` finds nothing.
 - **There is no explicit unsubscribe.** `contract.rs:915` carries
@@ -167,12 +168,23 @@ messages without acting on any of them.
 freenet-core#5273. The contract verbs share the root cause and are not recorded
 there.
 
-The V2 host functions behave differently, because they are wasmtime imports
-resolved inside the delegate's own execution rather than messages the node
-services afterwards. `Executor::from_config_local` delegates to `from_config`
-(`crates/core/src/contract/executor/runtime.rs:366`), which wires the state store
-those imports read and write (`:380`). So `ctx.get_contract_state` and
-`ctx.put_contract_state` do run under `freenet local`, against the local store.
+Three of the V2 host functions do work under `freenet local`, because they are
+wasmtime imports resolved inside the delegate's own execution rather than
+messages the node services afterwards. `Executor::from_config_local` delegates to
+`from_config` (`crates/core/src/contract/executor/runtime.rs:366`), which wires
+the state store they read and write (`:380`), so `ctx.get_contract_state`,
+`ctx.put_contract_state` and `ctx.update_contract_state` all hit the local store.
+
+`subscribe_contract` is the exception, and notification delivery is dead locally
+for both API versions. `send_delegate_contract_notifications` returns immediately
+when `delegate_notification_tx` is `None` (`executor_impl.rs:2169-2172`), and that
+field is set only by `RuntimePool` (`contract/executor/runtime/pool.rs:538`,
+`:563`, `:816`). `freenet local` builds a plain `Executor` through
+`from_config_local` (`crates/core/src/bin/freenet.rs:183`), which leaves it `None`
+(`contract/executor.rs:1685`). Nothing drains the channel in local mode either:
+`take_delegate_notification_rx` has one caller, `contract.rs:1276`, inside
+`contract_handling`. So a local `subscribe_contract` returns `true`, registers in
+`DELEGATE_SUBSCRIPTIONS`, and can never fire.
 
 **The rule that falls out:** test a delegate's contract access against a real
 node. A V1 delegate that works on the network does nothing under `freenet local`,
@@ -249,15 +261,14 @@ reordering either enum is a wire break. `inbound_delegate_msg_wire_format_is_sta
 that test, so do not rely on CI to catch it.
 
 One trap when reading the source: the doc comment above `InboundDelegateMsg`
-(`delegate_interface.rs:517-518`) says its `#[non_exhaustive]` "matches the
+(`delegate_interface.rs:518-519`) says its `#[non_exhaustive]` "matches the
 pre-existing `#[non_exhaustive]` on `OutboundDelegateMsg`". `OutboundDelegateMsg`
 does not carry that attribute. Trust the attribute, not the comment.
 
-The asymmetry is a wart rather than a design, so it may be closed. If a later
-stdlib marks `OutboundDelegateMsg` `#[non_exhaustive]` too, an exhaustive match
-on it stops compiling and a wildcard arm becomes required on both sides. Check
-the attribute in the stdlib version you build against rather than trusting the
-listings here.
+Check the attribute in the stdlib version you build against rather than trusting
+the listings here. If a later stdlib marks `OutboundDelegateMsg`
+`#[non_exhaustive]` too, an exhaustive match on it stops compiling and a wildcard
+arm becomes required on both sides.
 
 ## V2 Host Functions: Direct Contract Access
 
@@ -269,8 +280,9 @@ There are two live delegate API versions, and a delegate may use either.
 `DelegateContext`. The loop is at `crates/core/src/contract.rs:591` and is
 bounded by `MAX_CONTRACT_REQUEST_ITERATIONS = 100` (`contract.rs:60`). On
 overflow it returns whatever it accumulated so far (`contract.rs:600`) rather
-than erroring, so a delegate that exceeds the bound sees a truncated result and
-no failure signal. Whether that should be an error is freenet-core#5454.
+than erroring. The delegate is simply not re-invoked, and the client receives a
+truncated set of outbound messages with no failure signal. Whether that should be
+an error is freenet-core#5454.
 
 **V2, synchronous host calls.** Methods on `DelegateCtx` that return in-line,
 with no continuation to manage:
@@ -284,8 +296,9 @@ ctx.create_delegate(wasm, params, cipher, nonce)          // -> Result<([u8; 32]
 ```
 
 `get_contract_state_len` is the paired length query the two-step read protocol
-uses. The first five import from the `freenet_delegate_contracts` namespace and
-`create_delegate` from `freenet_delegate_management`. Both are registered in the
+uses. Those four plus `get_contract_state_len` import from the
+`freenet_delegate_contracts` namespace, and `create_delegate` from
+`freenet_delegate_management`. Both are registered in the
 wasmtime linker (`wasmtime_engine.rs:2035` and `:2117`), and core decides a
 module is V2 by scanning its imports (`wasmtime_engine.rs:923`). The
 implementations are in `crates/core/src/wasm_runtime/native_api.rs`.
@@ -298,14 +311,16 @@ call site says otherwise. On writes they diverge, and the V2 call still returns
 success and still reads back locally, so a single-node test cannot tell them
 apart. Three things to know:
 
-- **V2 writes reach the network LESS than V1 writes, not the same amount.** V1
+- **V2 writes reach the network LESS than V1 writes.** V1
   PUT and UPDATE go through `upsert_contract_state` into `commit_state_update`
   (`executor_impl.rs:1996`), which emits `NodeEvent::BroadcastStateChange` and
   notifies subscribed delegates. V2 `put_contract_state` and
   `update_contract_state` bottom out in `put_contract_state_sync` /
   `update_contract_state_sync` (`native_api.rs:796` and `:849`), which write to
-  ReDb directly. Their own comments say the path "bypasses the executor's
-  `state_store.store` call site". There is no broadcast and no delegate
+  ReDb directly. The comment on the first says "the V2 path bypasses the
+  executor `state_store` chokepoint" (`native_api.rs:814-816`), and the wiring
+  site says the same (`contract/executor/runtime.rs:381-384`). There is no
+  broadcast and no delegate
   notification on that path at all, so a V2 write lands on local disk and stops.
   This is freenet-core#5479, open. Until it is fixed, use the V1
   `PutContractRequest` / `UpdateContractRequest` messages for any write whose
@@ -315,12 +330,13 @@ apart. Three things to know:
   `get_contract_state` reads the same local store.
 - **`update_contract_state` is a full state replacement.** It does not run the
   contract's `update_state` merge logic, and it fails if there is no prior state
-  (stdlib `delegate_host.rs:573-580`).
+  (stdlib `delegate_host.rs:574-580`).
 
 ## Resource Limits
 
-A delegate is not unguarded. The guard that matters is per-invocation
-preemption, and it is not fuel.
+A delegate is not unguarded. The guard that carries the weight is per-invocation
+preemption by the wasmtime epoch deadline. Fuel metering is off in production, so
+it guards nothing today.
 
 - **Epoch preemption.** `max_execution_seconds` defaults to 5.0
   (`crates/core/src/wasm_runtime/runtime.rs:742`), enforced by wasmtime epoch
@@ -347,8 +363,11 @@ preemption, and it is not fuel.
 
 What has no guard today, so do not design as though it did:
 
-- **No cross-invocation cost accounting.** Every limit above bounds one call.
-  Nothing bounds a delegate that makes many cheap calls indefinitely.
+- **No cross-invocation cost accounting.** The execution and memory limits above
+  bound one call each. Nothing measures or bounds the CPU and memory a delegate
+  consumes across many cheap calls. The registry caps are the exception: the
+  child-delegate and app-registration bounds do span invocations, and they bound
+  counts rather than cost.
 - **The epoch trap only interrupts guest code.** Wasmtime's epoch checks sit at
   wasm loop backedges and function entries, so a blocking host call in flight is
   never cut off; the trap fires only once control returns to guest code

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -2,7 +2,11 @@
 
 Delegates are WebAssembly agents that run locally on the user's device within freenet-core. They act as a "trust zone" for private operations.
 
-> **Note:** Not all delegate capabilities are fully implemented yet. This document focuses on patterns used in River. Features like user permission requests and background monitoring may have limited support.
+> **Note:** This document focuses on patterns used in River. Read
+> [Delegate Capabilities](#delegate-capabilities) before designing around
+> contract access or background work. Several delegate verbs exist and their
+> handlers run, but stay local to this node, and the difference decides whether
+> an app works once the browser tab closes.
 
 ## DelegateInterface Trait
 
@@ -29,70 +33,250 @@ impl DelegateInterface for MyDelegate {
 ## Delegate Capabilities
 
 **Implemented and usable today:**
-- Store private data on behalf of users (secrets, keys, preferences)
+- Store private data on behalf of users (secrets, keys, preferences) through
+  `DelegateCtx::get_secret` / `set_secret` / `has_secret` / `remove_secret` /
+  `list_secrets` (freenet-stdlib `rust/src/delegate_host.rs:344-466`)
 - Send/receive messages from UIs, and from *other apps* on the same node
 - Perform cryptographic operations (signing, encryption)
-- **Read, write, and subscribe to contracts** — `OutboundDelegateMsg` carries
-  `GetContractRequest`, `PutContractRequest`, `UpdateContractRequest` and
-  `SubscribeContractRequest`, each with handlers in freenet-core
-- **Request user permission** via `OutboundDelegateMsg::RequestUserInput`; the
-  runtime renders the prompt. The ghostkeys delegate ships this in production
-- **Run as a long-running background service.** A delegate that subscribes to a
-  contract is woken by `InboundDelegateMsg::ContractNotification` whenever that
-  contract's state changes, with no UI open. Core keeps a `DELEGATE_SUBSCRIPTIONS`
-  registry mapping contract → interested delegates
+- **Request user permission** via `OutboundDelegateMsg::RequestUserInput`. The
+  node's `DashboardPrompter` renders the prompt, opening the permission page in
+  the user's browser if no dashboard tab is connected
+  (`crates/core/src/contract/user_input.rs:188`, wired at
+  `crates/core/src/node/p2p_impl.rs:950`). The ghostkeys delegate ships this in
+  production
 - Message another delegate on the same node via `SendDelegateMessage`
+- **Create a child delegate at runtime** via `DelegateCtx::create_delegate`
+  (stdlib `delegate_host.rs:642`), a host function in the
+  `freenet_delegate_management` namespace registered at
+  `crates/core/src/wasm_runtime/engine/wasmtime_engine.rs:2117`. This file used
+  to list delegate creation under "still not implemented", reasoning that no
+  such variant exists on `OutboundDelegateMsg`. The variant genuinely does not
+  exist and the capability is a host function rather than an outbound message,
+  so its absence proved nothing.
 
-**Still not implemented:**
-- Creating other delegates from within a delegate (no such variant exists on
-  `OutboundDelegateMsg`)
+**Implemented, but local to this node.** A delegate can read, write and
+subscribe to contracts, and every one of those handlers runs. What none of them
+do is reach the network the way the equivalent client request does. Verified
+against freenet-core `main` @ `b863ee7c6`:
 
-> This list previously described contract access, user permission and background
-> tasks as "planned but not yet fully implemented", which contradicted SKILL.md
-> and steered readers away from the subscription-driven background-service
-> pattern that core actually supports. Verified against freenet-stdlib
-> `delegate_interface.rs` and freenet-core.
+| Verb | Local | Network |
+|---|---|---|
+| `GetContractRequest` | reads the local state store | nothing. No GET operation is started |
+| `PutContractRequest` | stores locally | broadcast to peers already interested. No routing PUT |
+| `UpdateContractRequest` | applies locally | same broadcast as PUT |
+| `SubscribeContractRequest` | registers a local notification hook | nothing. No demand is registered |
+
+- **A delegate GET only sees contracts this node already holds.** The handler is
+  gated on `executor().lookup_key(&contract_id)` resolving locally
+  (`crates/core/src/contract.rs:758`), and when it does resolve the fetch bottoms
+  out in `perform_contract_get`
+  (`crates/core/src/contract/executor/runtime/executor_impl.rs:1431`), which is a
+  `state_store.get(&key)` and nothing else. The delegate gets `None` for anything
+  the node does not hold. The V2 error code says the same thing in words:
+  `ERR_CONTRACT_NOT_FOUND (-7): contract not in local store`
+  (`crates/core/src/wasm_runtime/native_api.rs:1734`). A fix is in progress under
+  the freenet-core#5467 epic; re-check this before relying on either behaviour.
+- **A delegate PUT is not a client PUT.** It calls `upsert_contract_state`
+  (`contract.rs:714`), which stores locally and emits
+  `NodeEvent::BroadcastStateChange` (`crates/core/src/message.rs:953`), fanning
+  the new state out to peers that are *already* interested in the contract. A
+  client PUT instead opens a `put::PutMsg` transaction and routes toward the key
+  (`crates/core/src/client_events.rs:519`, whose own comment reads "finds peers,
+  sends the request"). A delegate PUT of a contract nobody is yet interested in
+  therefore lands on this node and nowhere else.
+- **A delegate UPDATE takes only `UpdateData::State` and `UpdateData::Delta`.**
+  `StateAndDelta` and every `Related*` variant are rejected with
+  `Err("Unsupported UpdateData variant")`, because the delegate API has no way to
+  supply the related-contract context (`contract.rs:820-855`). UPDATE also needs
+  the contract to resolve locally and returns `Err("Contract not found")`
+  otherwise.
+- **A delegate subscription registers no network demand.** It inserts into
+  `DELEGATE_SUBSCRIPTIONS` (`crates/core/src/wasm_runtime/native_api.rs:40`), a
+  process-global `DashMap<ContractInstanceId, HashSet<DelegateKey>>` that only
+  the notification-delivery path reads. Nothing in `ring/` reads it, and
+  `contract_in_use` (`crates/core/src/ring/hosting.rs:1725`) is still
+  `has_client_subscriptions(..) || has_downstream_subscribers(..)` with no
+  delegate term. So a delegate subscribe does not set `contract_in_use`, does not
+  enter `contracts_needing_renewal()`, and does not exempt the contract from
+  eviction. This is freenet-core#4669, Phase 1 of the freenet-core#5467 epic,
+  open with the design signed off, and a fix is in progress.
+- **Subscribing also requires the contract to be known locally.** Both
+  registration paths validate with `lookup_key` before inserting: V1 at
+  `contract.rs:929`, V2 at `native_api.rs:901`.
+- **There is no explicit unsubscribe.** `contract.rs:915` carries
+  `TODO(#2830): UnsubscribeContractRequest is not yet handled`. That issue is
+  closed and the remaining gap is tracked under freenet-core#5467 Phase 1. Today
+  a delegate unsubscribes only implicitly, through `UnregisterDelegate` cleanup.
+
+**The notification claim this file used to make, corrected.** It said a
+subscribed delegate "is woken by `InboundDelegateMsg::ContractNotification`
+whenever that contract's state changes, with no UI open". Two things are wrong
+with that. `send_delegate_contract_notifications` (`executor_impl.rs:2168`) fires
+on any *local* state commit, so the delegate is woken only when this node's copy
+changes. For a write that happened elsewhere, that means the node has to be
+subscribed to the contract by some other route, and in practice the other route
+is the app's own UI WebSocket, which goes away when the tab closes. The pattern
+stops working at exactly the moment it was supposed to earn its keep. That is the
+failure freenet/delta#30 hit. Delivery is also best-effort: the notification is a
+`try_send` on a bounded channel and is dropped when the channel is full
+(`executor_impl.rs:2196`), so a delegate that needs certainty has to poll the
+contract state as well.
+
+## What a Delegate Is Not Good For Yet
+
+- **Keeping a user's content alive in the network.** Pinning content by
+  subscribing to it is exactly what a delegate subscription looks like it does,
+  and it does not (freenet-core#4669).
+- **Autonomous background work.** There is no scheduled wakeup. A delegate runs
+  when something pokes it: an application message, a user response, or a contract
+  notification for a contract this node already tracks. `ScheduleWakeup` /
+  `WakeupFired` are drafted in freenet-stdlib#82 and a host-side implementation
+  was built and shelved in freenet-core#4666; both sit under freenet-core#3972.
+- **Fetching arbitrary contracts from the network.** See the GET row above. A
+  delegate is not a way to reach content the node does not already hold.
+- **Knowing its own state after a restart.** A delegate cannot ask what it is
+  currently subscribed to, so it has nothing to reconcile against on restart.
+  Introspection is part of freenet-core#5467 Phase 1.
 
 ## Message Types
+
+Both enums live in freenet-stdlib `rust/src/delegate_interface.rs`, inbound at
+`:524` and outbound at `:701`.
 
 ### Inbound Messages
 
 ```rust
-pub enum InboundDelegateMsg {
-    /// Message from an application (UI or contract)
+/// Host -> delegate. `#[non_exhaustive]`, so a `match` on it MUST carry a
+/// wildcard arm or it will not compile against a later stdlib.
+#[non_exhaustive]
+pub enum InboundDelegateMsg<'a> {
     ApplicationMessage(ApplicationMessage),
-
-    /// Response to a secret retrieval request
-    GetSecretResponse(GetSecretResponse),
-
-    /// User's response to a permission/input request
-    UserResponse(UserResponse),
-
-    /// Request to retrieve a secret
-    GetSecretRequest(GetSecretRequest),
+    UserResponse(UserInputResponse<'a>),
+    GetContractResponse(GetContractResponse),
+    PutContractResponse(PutContractResponse),
+    UpdateContractResponse(UpdateContractResponse),
+    SubscribeContractResponse(SubscribeContractResponse),
+    ContractNotification(ContractNotification),
+    DelegateMessage(DelegateMessage),
 }
 ```
 
 ### Outbound Messages
 
 ```rust
+/// Delegate -> host. NOT `#[non_exhaustive]`: adding a variant here breaks
+/// every delegate that matches exhaustively on it.
 pub enum OutboundDelegateMsg {
-    /// Message to an application
     ApplicationMessage(ApplicationMessage),
-
-    /// Request user input or permission
-    RequestUserInput(UserInputRequest),
-
-    /// Retrieve a stored secret
-    GetSecretRequest(GetSecretRequest),
-
-    /// Store a new secret
-    SetSecretRequest(SetSecretRequest),
-
-    /// Update delegate context (for async operations)
+    RequestUserInput(UserInputRequest<'static>),
     ContextUpdated(DelegateContext),
+    GetContractRequest(GetContractRequest),
+    PutContractRequest(PutContractRequest),
+    UpdateContractRequest(UpdateContractRequest),
+    SubscribeContractRequest(SubscribeContractRequest),
+    SendDelegateMessage(DelegateMessage),
 }
 ```
+
+The listings this file previously carried were pre-v0.5. They showed
+`GetSecretRequest`, `GetSecretResponse` and `SetSecretRequest` as message
+variants and omitted every contract variant. Those secret variants no longer
+exist in either enum; secrets are `DelegateCtx` methods now.
+
+Wire format is bincode, with the variant index taken from declaration order, so
+reordering either enum is a wire break. `inbound_delegate_msg_wire_format_is_stable`
+pins the inbound tags.
+
+One trap when reading the source: the doc comment above `InboundDelegateMsg`
+(`delegate_interface.rs:518`) says its `#[non_exhaustive]` "matches the
+pre-existing `#[non_exhaustive]` on `OutboundDelegateMsg`". `OutboundDelegateMsg`
+does not carry that attribute. Trust the attribute, not the comment.
+
+## V2 Host Functions: Direct Contract Access
+
+There are two live delegate API versions, and a delegate may use either.
+
+**V1, request and response.** `process()` returns e.g.
+`OutboundDelegateMsg::GetContractRequest`; the host handles it and re-invokes
+`process()` with `GetContractResponse`. Continuation state rides in
+`DelegateContext`. The loop is at `crates/core/src/contract.rs:590` and is
+bounded by `MAX_CONTRACT_REQUEST_ITERATIONS = 100` (`contract.rs:60`). On
+overflow it returns whatever it accumulated so far (`contract.rs:598`) rather
+than erroring, so a delegate that exceeds the bound sees a truncated result and
+no failure signal. Whether that should be an error is freenet-core#5454.
+
+**V2, synchronous host calls.** Methods on `DelegateCtx` that return in-line,
+with no continuation to manage:
+
+```rust
+ctx.get_contract_state(&instance_id)                      // -> Option<Vec<u8>>
+ctx.put_contract_state(&instance_id, state)               // -> bool
+ctx.update_contract_state(&instance_id, state)            // -> bool
+ctx.subscribe_contract(&instance_id)                      // -> bool
+ctx.create_delegate(wasm, params, cipher, nonce)          // -> Result<([u8; 32], [u8; 32]), i32>
+```
+
+The first four import from the `freenet_delegate_contracts` namespace and
+`create_delegate` from `freenet_delegate_management`. Both are registered in the
+wasmtime linker (`wasmtime_engine.rs:2035` and `:2117`), and core decides a
+module is V2 by scanning its imports (`wasmtime_engine.rs:923`). The
+implementations are in `crates/core/src/wasm_runtime/native_api.rs`.
+
+Two things to know before reaching for V2:
+
+- **The local-only limits above apply identically.** Both API versions converge
+  on the same handlers, and V2's `subscribe_contract` writes to the same
+  `DELEGATE_SUBSCRIPTIONS` registry. V2 changes the calling convention, not what
+  reaches the network.
+- **`update_contract_state` is a full state replacement.** It does not run the
+  contract's `update_state` merge logic, and it fails if there is no prior state
+  (stdlib `delegate_host.rs:573-580`).
+
+## Resource Limits
+
+A delegate is not unguarded. The guard that matters is per-invocation
+preemption, and it is not fuel.
+
+- **Wall-clock preemption.** `max_execution_seconds` defaults to 5.0
+  (`crates/core/src/wasm_runtime/runtime.rs:742`), enforced by wasmtime epoch
+  interruption. A background thread bumps the epoch every
+  `EPOCH_TICK_PERIOD = 100ms` (`wasmtime_engine.rs:453`), and every guest entry
+  arms a deadline of `ceil(max_execution_seconds / tick) + 1` ticks
+  (`epoch_deadline_ticks`, `:679`) with `epoch_deadline_trap()`, which kills a
+  runaway guest rather than pausing it. The V2 delegate entry point
+  (`call_3i64_async_imports`, `:1132`) arms it like every other, and a
+  source-scrape test asserts that every guest entry does. Note it interrupts
+  guest code only: a host call already in flight runs to completion.
+- **Memory** is capped at `DEFAULT_MAX_MEMORY_PAGES` (256 MiB) by a wasmtime
+  `ResourceLimiter` installed on the store (`wasmtime_engine.rs:841`).
+- **Fuel metering is off in production.** `enable_metering` defaults to `false`
+  (`runtime.rs:745`) and is set true only in tests. Do not reason about a
+  delegate's cost bound in terms of fuel.
+- **Child delegate creation** is bounded three ways: depth 4, 8 creations per
+  `process()` call, and 1024 created delegates per node
+  (`crates/core/src/contract/executor.rs:111-120`), with a 10 MiB cap on the
+  submitted WASM (`native_api.rs:618`).
+- **App registrations** are bounded: `MAX_APPS_PER_DELEGATE = 128`,
+  `MAX_DELEGATES_PER_CLIENT = 256`, and a 30-minute `REGISTRATION_TTL` sweep
+  (`crates/core/src/contract/delegate_app_registry.rs:55-88`).
+
+What has no guard today, so do not design as though it did:
+
+- **No cross-invocation cost accounting.** Every limit above bounds one call.
+  Nothing bounds a delegate that makes many cheap calls indefinitely.
+- **`DELEGATE_SUBSCRIPTIONS` is unbounded.** One delegate may hold unlimited
+  subscriptions, subject only to each contract being known locally. That the
+  registry is a process-global rather than per-node state is itself a known
+  defect, freenet-core#4824.
+- **No quarantine, throttle or circuit breaker** for a delegate that panics on
+  every invocation or spins. A containment ladder is designed in
+  freenet-core#5467 Phase 4 and not built. freenet-core#3978, rate-limiting
+  delegate-not-found probes, is also still open.
+- **No per-delegate observability at all.** You cannot see what a delegate did,
+  what it is subscribed to, or what it cost. That is freenet-core#5467 Phase 0,
+  and it is why the subscription gap above survived so long: the subscribe call
+  succeeds, notification delivery works, and nothing reports that the pin never
+  took.
 
 ## Secret Storage Pattern
 
@@ -230,9 +414,13 @@ fn process(..., message: InboundDelegateMsg) -> Result<Vec<OutboundDelegateMsg>,
 }
 ```
 
-## User Permission Pattern (Limited Support)
+## User Permission Pattern
 
-Request user confirmation for sensitive operations. Note: This feature may have limited support in the current Freenet implementation.
+Request user confirmation for sensitive operations. This is wired end to end:
+the node's `DashboardPrompter` (`crates/core/src/contract/user_input.rs:188`)
+holds the pending prompt, and opens the standalone permission page in the user's
+browser when no dashboard tab is connected. An unanswered prompt auto-denies
+after `USER_INPUT_TIMEOUT` (60 seconds, `user_input.rs:10`).
 
 ```rust
 fn process(...) -> Result<Vec<OutboundDelegateMsg>, DelegateError> {


### PR DESCRIPTION
## Problem

`skills/dapp-builder/references/delegate-patterns.md` described a delegate API that does not exist. The dangerous line was this one:

> A delegate that subscribes to a contract is woken by `InboundDelegateMsg::ContractNotification` whenever that contract's state changes, with no UI open.

That is only true when the node is subscribed to the contract by some other route, and in practice that route is the app's own UI WebSocket, which goes away when the tab closes. The pattern stops working at exactly the moment it was supposed to earn its keep. That is the failure freenet/delta#30 hit.

Four more, in the same file:

- "Read, write, and subscribe to contracts" sat under **Implemented and usable today** with no caveat. A delegate GET reads the local store only, a delegate SUBSCRIBE registers no network demand, and a delegate PUT broadcasts to already-interested peers without the routing a client PUT performs.
- "Creating other delegates from within a delegate" was listed under **Still not implemented**, reasoning that no such variant exists on `OutboundDelegateMsg`. The variant does not exist and the capability is a host function, so its absence proved nothing.
- Both message-enum listings were pre-v0.5: they showed `GetSecretRequest` / `GetSecretResponse` / `SetSecretRequest`, none of which exist any more, and omitted every contract variant.
- Nothing documented resource limits, execution timeout, memory cap or containment.

## Approach

Corrections written the way `b925152` wrote its: state plainly that the old claim was wrong, say what is actually true, cite where it was verified, and give the rule that falls out. Verified against freenet-core `main` @ `b863ee7c6` and freenet-stdlib `main` @ `99ee584`.

The additions the reader is most likely to need:

**`freenet local` does not run the delegate contract loop at all.** `handle_delegate_with_contract_requests` (`crates/core/src/contract.rs:537`) has two call sites, both under `contract_handling` (`:1268`), which is spawned from one production site, `node/p2p_impl.rs:948`, the network node. `run_local_node` (`node.rs:5768`) handles `ClientRequest::DelegateOp` by calling `executor.delegate_request(...)` directly (`:5851`), so a V1 delegate's GET, PUT, UPDATE and SUBSCRIBE are never acted on and nothing reports an error. freenet-core#5273 records the `RequestUserInput` symptom of the same root cause; the contract verbs are not recorded there. Three V2 host functions do work locally, and `subscribe_contract` does not, because notification delivery needs a `delegate_notification_tx` that only `RuntimePool` sets. An agent building a dApp reaches for `freenet local` first, so this is the fastest way to be misled.

**V1 and V2 expose the same operations under the same names and do not do the same thing on writes** (freenet-core#5479). V1 PUT and UPDATE go through `upsert_contract_state` into `commit_state_update`, which broadcasts and notifies. V2 `put_contract_state` / `update_contract_state` are raw ReDb writes that bypass the executor chokepoint, so a V2 write lands on local disk and stops. The call returns success and reads back locally, so a single-node test cannot see it. This now leads the V2 section.

**Resource limits, stated precisely.** Epoch interruption is the real preemption guard and it does cover delegates: 100 ms tick, `max_execution_seconds` default 5.0, `epoch_deadline_trap()`, armed on both delegate entry points and pinned by a source-scrape test. Memory is capped at 256 MiB by a wasmtime `ResourceLimiter`. Fuel metering is off in production, so the file says not to reason about cost in terms of it. Then the gaps, named individually: no cross-invocation cost accounting, an unbounded subscription registry (freenet-core#4824), no containment for a delegate that panics every invocation (freenet-core#5467 Phase 4, designed not built), no per-delegate observability (Phase 0), and the two execution gaps in freenet-core#5480 (the epoch trap interrupts guest code only, and delegates never reach `execute_wasm_blocking`, so they get neither the wall-clock backstop nor the panic capture contracts get). The file does not say delegates are unguarded, because they are not.

Also new: a "What a Delegate Is Not Good For Yet" section covering durable pinning (freenet-core#4669), autonomous background work (no scheduled wakeup; freenet-core#3972, freenet-stdlib#82 draft), fetching arbitrary network contracts, and knowing its own subscriptions after a restart.

## Tense discipline

Fixes are in flight for several of these. Everything here describes `main` as of 2026-08-30 and cites the issue where a fix is pending. Nothing unshipped is documented as working. Where an earlier draft said a fix was "being worked on", that claim is now the checkable one instead: open, design signed off, nothing merged.

## Testing

Documentation only, no code. Verification was reading the cited code, plus an independent adversarial review that re-checked every `file:line` against both repos and challenged each substantive claim. It found six one-line citation drifts, one over-broad claim about V2 under `freenet local`, one unsupported "being worked on", a false "every limit bounds one call", a quotation that was not verbatim, a section label its own table contradicted, and three "not X, Y" constructions. All are fixed in `1a9dde6`.

`.claude-plugin/marketplace.json` bumped to 1.30.0 with a `CHANGELOG.md` entry.

[AI-assisted - Claude]
