### PR TITLE
docs(local-dev): delegates need network mode, and why (v1.31.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.30.0"
+    "version": "1.31.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.31.0 (2026-08-30)
+
+Adds one thing to `local-dev` that `dapp-builder` learned in 1.30.0: a delegate's
+contract requests are never serviced under `freenet local`.
+
+Every node recipe in the `local-dev` skill already uses `freenet network`, so the
+skill does not steer anyone wrong today. The gap is that it never says why that
+matters, and `freenet local` is the subcommand a reader of a local-development
+skill will reach for on their own. Its own help text calls local mode useful for
+development.
+
+- `handle_delegate_with_contract_requests` (`crates/core/src/contract.rs:537`)
+  has two call sites, both under `contract_handling` (`:1268`), which is spawned
+  from one production site, `node/p2p_impl.rs:948`, the network node.
+  `run_local_node` (`node.rs:5768`) handles `ClientRequest::DelegateOp` by
+  calling `executor.delegate_request(...)` straight through (`:5851`), which runs
+  `process()` and hands back its outbound messages without acting on them. So a
+  delegate's GET, PUT, UPDATE and SUBSCRIBE all do nothing under `freenet local`,
+  with no error anywhere. freenet-core#5273 records the `RequestUserInput`
+  symptom of the same root cause.
+- Delegate notification is dead in local mode as well:
+  `send_delegate_contract_notifications` returns immediately when
+  `delegate_notification_tx` is `None` (`executor_impl.rs:2169-2172`), and only
+  `RuntimePool` sets that field.
+- The V2 host functions are the exception, and the entry says so rather than
+  flattening it: `get_contract_state`, `put_contract_state` and
+  `update_contract_state` are wasmtime imports resolved inside the delegate's own
+  execution, so they do reach the local store. `subscribe_contract` registers and
+  can never fire.
+- A row in the "Common issues" table points at the new section, since a silent
+  no-op is exactly what sends someone to that table.
+
+Verified against freenet-core `main` @ `b863ee7c6`.
+
 ## 1.30.0 (2026-08-30)
 
 Corrects what `dapp-builder` says a delegate can do with contracts, and adds the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ skill will reach for on their own. Its own help text calls local mode useful for
 development.
 
 - `handle_delegate_with_contract_requests` (`crates/core/src/contract.rs:537`)
-  has two call sites, both under `contract_handling` (`:1268`), which is spawned
-  from one production site, `node/p2p_impl.rs:948`, the network node.
+  has two call sites, both reached from `contract_handling` (`:1268`) through
+  `handle_delegate_notification` (`:2076`) and `handle_contract_event` (`:2209`),
+  and `contract_handling` is spawned from one production site,
+  `node/p2p_impl.rs:948`, the network node.
   `run_local_node` (`node.rs:5768`) handles `ClientRequest::DelegateOp` by
   calling `executor.delegate_request(...)` straight through (`:5851`), which runs
   `process()` and hands back its outbound messages without acting on them. So a

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -507,9 +507,10 @@ does not service a delegate's contract requests at all.
 The loop that handles `GetContractRequest`, `PutContractRequest`,
 `UpdateContractRequest` and `SubscribeContractRequest` from a delegate is
 `handle_delegate_with_contract_requests` (`crates/core/src/contract.rs:537`).
-Both of its call sites sit under `contract_handling` (`:1268`), which is spawned
-from one production site, `crates/core/src/node/p2p_impl.rs:948`, the network
-node. `run_local_node` (`crates/core/src/node.rs:5768`) handles
+Both of its call sites are reached from `contract_handling` (`:1268`), through
+`handle_delegate_notification` (`:2076`) and `handle_contract_event` (`:2209`),
+and `contract_handling` is spawned from one production site,
+`crates/core/src/node/p2p_impl.rs:948`, the network node. `run_local_node` (`crates/core/src/node.rs:5768`) handles
 `ClientRequest::DelegateOp` by calling `executor.delegate_request(...)` straight
 through (`:5851`), which runs the delegate's `process()` and hands back its
 outbound messages without acting on any of them. Nothing reports an error, so

--- a/skills/local-dev/SKILL.md
+++ b/skills/local-dev/SKILL.md
@@ -495,6 +495,41 @@ the WebSocket connection.
 | Blank page (cached old WASM) | Mobile browser caches aggressively | Clear cache, force close browser, or use `?_v=timestamp` |
 | `sed -i` fails on macOS | BSD sed requires backup extension | Use build tools directly instead of sed |
 | `cargo make` targets Linux | Cross-compilation for web-container-tool | Build natively: `cargo build --release -p web-container-tool` |
+| A delegate's contract GET/PUT/UPDATE/SUBSCRIBE silently does nothing | Node started with `freenet local` | Start with `freenet network` as every recipe here does. See [Delegates need network mode](#delegates-need-network-mode) |
+
+### Delegates need network mode
+
+Every node recipe in this skill uses `freenet network`, and delegates are one of
+the reasons to keep it that way. `freenet local` is the mode whose own help text
+calls it useful for development, so it is the natural thing to reach for, and it
+does not service a delegate's contract requests at all.
+
+The loop that handles `GetContractRequest`, `PutContractRequest`,
+`UpdateContractRequest` and `SubscribeContractRequest` from a delegate is
+`handle_delegate_with_contract_requests` (`crates/core/src/contract.rs:537`).
+Both of its call sites sit under `contract_handling` (`:1268`), which is spawned
+from one production site, `crates/core/src/node/p2p_impl.rs:948`, the network
+node. `run_local_node` (`crates/core/src/node.rs:5768`) handles
+`ClientRequest::DelegateOp` by calling `executor.delegate_request(...)` straight
+through (`:5851`), which runs the delegate's `process()` and hands back its
+outbound messages without acting on any of them. Nothing reports an error, so
+the delegate looks healthy and simply has no effect.
+
+Delegate notification is dead in local mode too, for the same reason:
+`send_delegate_contract_notifications` returns immediately when
+`delegate_notification_tx` is `None` (`executor_impl.rs:2169-2172`), and that
+field is set only by `RuntimePool`, which local mode does not build.
+`RequestUserInput` is lost the same way, which is freenet-core#5273.
+
+The V2 delegate host functions are the exception: `ctx.get_contract_state`,
+`ctx.put_contract_state` and `ctx.update_contract_state` are wasmtime imports
+resolved inside the delegate's own execution, so they do reach the local store
+under `freenet local`. `ctx.subscribe_contract` registers and can never fire.
+
+Verified against freenet-core `main` @ `b863ee7c6` on 2026-08-30. The
+`dapp-builder` skill's `references/delegate-patterns.md` has the full picture,
+including what a delegate's contract access does and does not reach on a real
+network node.
 
 ## Other Infrastructure
 


### PR DESCRIPTION
## Problem

`local-dev` is where someone goes to test a dApp locally, and `freenet local` is the subcommand they will reach for. Its own `--help` text, from the `clap::ValueEnum` variant at `crates/core/src/contract/executor.rs:801`, reads:

> Run the node in local-only mode. Useful for development purposes.

A delegate's contract requests are never serviced in that mode, and nothing reports an error. The delegate looks healthy and has no effect.

**One correction to how I originally pitched this.** I had said `local-dev` was the worse offender because it steers people to `freenet local`. It does not: every node-launch command in the skill (lines 92, 142, 145, 207, 208, 228, 240, 254) uses `freenet network`, and `Network` is the default mode anyway. So the skill does not steer anyone wrong today. The real gap is narrower: it never says why network mode matters, which leaves a reader who deviates on their own with a silent failure and nothing in the troubleshooting table to catch it. This PR is scoped to that, not to the larger rewrite I first described.

## Approach

One `###` subsection under `## Debugging`, plus one row in the existing "Common issues" table pointing at it, because a silent no-op is exactly what sends someone to that table.

`handle_delegate_with_contract_requests` (`crates/core/src/contract.rs:537`) has two call sites, both reached from `contract_handling` (`:1268`) through `handle_delegate_notification` (`:2076`) and `handle_contract_event` (`:2209`). `contract_handling` is spawned from one production site, `node/p2p_impl.rs:948`, the network node. `run_local_node` (`node.rs:5768`) handles `ClientRequest::DelegateOp` by calling `executor.delegate_request(...)` straight through (`:5851`), which runs `process()` and hands back its outbound messages without acting on any of them.

Delegate notification is dead locally for the same reason: `send_delegate_contract_notifications` returns immediately when `delegate_notification_tx` is `None` (`executor_impl.rs:2169-2172`), and only `RuntimePool` sets that field. `RequestUserInput` is lost the same way, which is freenet-core#5273.

The V2 host functions are the exception and the section says so rather than flattening it: `get_contract_state`, `put_contract_state` and `update_contract_state` are wasmtime imports resolved inside the delegate's own execution, so they do reach the local store. `subscribe_contract` registers and can never fire.

The full picture stays in `dapp-builder`'s `references/delegate-patterns.md` (#66). This is the pointer from the skill whose recipes actually start the node.

## Tense discipline

Deliberately scoped to survive the in-flight core fixes. #5479 (V2 propagation), #5481 (notification gap) and #4669 (subscribe demand) are all network-mode-scoped, and none of them changes the local-mode facts stated here: V2 reaches the *local* store, and `delegate_notification_tx` is `None` locally regardless. Verified against freenet-core `main` @ `b863ee7c6`.

## Testing

Documentation only. Verified by reading the cited code, plus an independent adversarial read that re-checked all six citations, confirmed there is no other path from `run_local_node` that services delegate contract requests, confirmed the "every recipe uses `freenet network`" claim by reading the whole skill, confirmed the anchor slug matches the heading, and checked the text against the three in-flight fixes. It found one cosmetic wording issue ("under" reading as lexical nesting), fixed in `d0c4aba`.

`.claude-plugin/marketplace.json` bumped to 1.31.0 with a `CHANGELOG.md` entry.

[AI-assisted - Claude]
