### PR TITLE
docs(dapp-builder): migration field corrections, marker placement, and two new rules (v1.35.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.34.0"
+    "version": "1.35.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.33.1"
+    "version": "1.34.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ pieces of doctrine that came out of the same app.
   "the params bytes used to derive the key".** They do not, which is the whole
   premise of the new parameter rule. Corrected, with the warning placed on the
   backward-probe recipe itself rather than only in `upgrade-and-migration.md`.
+- **The parameter rule got two limits from the external review pass.** A
+  generation boundary only works while each historical encoding maps onto a
+  distinct code hash — `freenet-migrate-build` rejects a duplicate contract code
+  hash, so two parameter-only re-keys on byte-identical WASM cannot both be
+  rows; the general answer is an app-derived `(code_hash, params)` candidate
+  list. And *noticing* you need a row is silent on the delegate side too: a
+  parameters-only re-key leaves the WASM unchanged, so a code-hash-comparing
+  publish guard says "unchanged" and `validate()` cannot object to a row nobody
+  wrote. An earlier draft of this entry claimed the delegate side "fails the
+  build"; only the registry *format* differs, not the detection.
 - **NEW: `Ok(vec![])` is a positive claim and seals a predecessor
   permanently.** An empty-success answer from `fetch_secrets` is
   indistinguishable from "nothing was there" and writes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 1.34.0 (2026-09-04)
 
-Six corrections from actually adopting `freenet-migrate` in a live app
+Seven corrections from actually adopting `freenet-migrate` in a live app
 (Harvest, `feat/bitcoin-payments`). These are field findings, not review
 speculation — each one is something the skill as written would have led an
 engineer into.
@@ -13,8 +13,8 @@ engineer into.
   `delegate-patterns.md` read as though adopting the crate carries an app's
   existing delegate secrets forward. It does not: the successor *asks*, and only
   a predecessor whose already-deployed WASM can answer will. New section, "A
-  delegate migration is forward-only", placed ahead of the mechanics because it
-  is a scheduling decision: **every release shipped without an export handler
+  delegate migration is forward-only", because this is a scheduling decision
+  before it is a coding one: **every release shipped without an export handler
   adds one permanently unrecoverable generation**, which makes "we have no
   migration to do yet" the argument for adopting sooner rather than a reason to
   defer. Covers `handle_export_request`, fail-closed origin policy, prefix vs.
@@ -23,22 +23,27 @@ engineer into.
   `upgrade-and-migration.md` step 4.
 - **"There is no export handler" was stale and read as a general claim.** True
   of the stdlib wire protocol; false of `freenet-migrate`, which has shipped
-  `handle_export_request` since 0.5.0. River's predecessors need no *special*
-  handler only because its chat delegate already answered a general-purpose
-  `GetRequest`/`ListRequest` over its own secret namespace — which most
-  delegates do not.
+  `handle_export_request` since 0.3.0. Corrected in all three places it appeared
+  (`SKILL.md`, `delegate-patterns.md`, `upgrade-and-migration.md`). River's
+  predecessors need no *special* handler only because its chat delegate already
+  answered a general-purpose `GetRequest`/`ListRequest` over its own secret
+  namespace — which most delegates do not. Note the caller is the app, not the
+  successor delegate: River's `check_origin` rejects delegate-to-delegate calls
+  outright, and the UI bridges the two generations under a stable WebApp
+  origin.
 - **Registry placement gets the constraint that actually forbids the wrong
   choice.** "Placement follows who probes" (added in 1.33.0) is right, but does
-  not rule anything out on its own. Added: **never code-generate a registry from
-  a crate inside the contract build graph** — if the shared crate compiles into
-  the contracts, editing the registry re-keys every contract that registry
-  describes, so you have built a registry that causes the migration it records.
-  Decide from the dependency direction, not from which crate is called
-  "common": in Harvest, `harvest-common` compiles into all three contracts and
-  the delegate while `harvest-ui` compiles into none.
+  not rule anything out on its own. Added the invariant that does: **a one-line
+  registry edit must not change the contract WASM bytes**, or the registry
+  causes the migration it exists to record. Two shapes satisfy it — the registry
+  outside the contract build graph (Harvest: `harvest-common` compiles into all
+  three contracts and the delegate, `harvest-ui` into none), or inside it but
+  `#[cfg]`-gated off the contract builds (River's `river-core`, which an outside
+  integrator needs). Verify with a WASM hash check, not `cargo tree`, which
+  reports crate edges rather than whether bytes moved.
 - **`ProbeDriver`, not `migrate_contract`, in shared-handler environments.**
   `migrate_contract` needs awaitable request/response correlation; a browser
-  app has none, because `WebApi` delivers every response to a single
+  app on stdlib's Rust `WebApi` has none, because it delivers every response to a single
   app-registered handler. `contract-patterns.md` now says which entry point
   suits which environment and gives the hand-pump sequence.
 - **A guard that provably cannot fail needs a source-scrape pin, not a
@@ -54,9 +59,10 @@ engineer into.
   re-keyed too. Browser `localStorage`, hex-encoded, keyed by artifact +
   instance + current code hash; unreadable storage must report "not migrated"
   so the probe repeats.
-- **`DEFAULT_CIPHER`/`DEFAULT_NONCE` is not the only stdlib 0.6→0.8 break.**
-  `ContractInstanceId::from_bytes` is deprecated in favour of `from_base58`,
-  which fails a build under `-D warnings`. Also notes what the rename reveals:
+- **`DEFAULT_CIPHER`/`DEFAULT_NONCE` is not the only stdlib break on the way to
+  current.** `ContractInstanceId::from_bytes` is deprecated in favour of
+  `from_base58` as of **0.8.5** (it does not exist in 0.8.2–0.8.4), which fails a
+  build under `-D warnings`. Also notes what the rename reveals:
   it parses base58 *text*, so code passing it a raw 32-byte id was already
   wrong and wants `ContractInstanceId::new`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,64 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.34.0 (2026-09-04)
+
+Six corrections from actually adopting `freenet-migrate` in a live app
+(Harvest, `feat/bitcoin-payments`). These are field findings, not review
+speculation — each one is something the skill as written would have led an
+engineer into.
+
+- **A delegate migration is FORWARD-ONLY, and that changes when you adopt.**
+  `delegate-patterns.md` read as though adopting the crate carries an app's
+  existing delegate secrets forward. It does not: the successor *asks*, and only
+  a predecessor whose already-deployed WASM can answer will. New section, "A
+  delegate migration is forward-only", placed ahead of the mechanics because it
+  is a scheduling decision: **every release shipped without an export handler
+  adds one permanently unrecoverable generation**, which makes "we have no
+  migration to do yet" the argument for adopting sooner rather than a reason to
+  defer. Covers `handle_export_request`, fail-closed origin policy, prefix vs.
+  whole-scope export, and the two residual limits (`HOST_ENUMERATION_CAP`
+  truncation refusal, pre-registry keys). Cross-linked from
+  `upgrade-and-migration.md` step 4.
+- **"There is no export handler" was stale and read as a general claim.** True
+  of the stdlib wire protocol; false of `freenet-migrate`, which has shipped
+  `handle_export_request` since 0.5.0. River's predecessors need no *special*
+  handler only because its chat delegate already answered a general-purpose
+  `GetRequest`/`ListRequest` over its own secret namespace — which most
+  delegates do not.
+- **Registry placement gets the constraint that actually forbids the wrong
+  choice.** "Placement follows who probes" (added in 1.33.0) is right, but does
+  not rule anything out on its own. Added: **never code-generate a registry from
+  a crate inside the contract build graph** — if the shared crate compiles into
+  the contracts, editing the registry re-keys every contract that registry
+  describes, so you have built a registry that causes the migration it records.
+  Decide from the dependency direction, not from which crate is called
+  "common": in Harvest, `harvest-common` compiles into all three contracts and
+  the delegate while `harvest-ui` compiles into none.
+- **`ProbeDriver`, not `migrate_contract`, in shared-handler environments.**
+  `migrate_contract` needs awaitable request/response correlation; a browser
+  app has none, because `WebApi` delivers every response to a single
+  app-registered handler. `contract-patterns.md` now says which entry point
+  suits which environment and gives the hand-pump sequence.
+- **A guard that provably cannot fail needs a source-scrape pin, not a
+  behavioural test.** "Verify by mutation" has no answer for a wildcard arm over
+  a `#[non_exhaustive]` enum: while every variant is named, the arm is
+  unreachable, so inverting it to the unsafe default leaves the suite green
+  (Harvest's `seal_decision`). The remedy is a source pin kept *alongside* the
+  behavioural test — otherwise the general warning about source pins gets
+  applied to the one case where a source pin is correct.
+- **Never put a contract migration marker in the delegate.** It is the obvious
+  home and it is wrong: the marker is lost when the *delegate* re-keys, which
+  silently resets every contract marker at exactly the moment the contracts
+  re-keyed too. Browser `localStorage`, hex-encoded, keyed by artifact +
+  instance + current code hash; unreadable storage must report "not migrated"
+  so the probe repeats.
+- **`DEFAULT_CIPHER`/`DEFAULT_NONCE` is not the only stdlib 0.6→0.8 break.**
+  `ContractInstanceId::from_bytes` is deprecated in favour of `from_base58`,
+  which fails a build under `-D warnings`. Also notes what the rename reveals:
+  it parses base58 *text*, so code passing it a raw 32-byte id was already
+  wrong and wants `ContractInstanceId::new`.
+
 ## 1.33.1 (2026-09-04)
 
 `ui-patterns.md` told you to derive the WebSocket URL and, 30 lines earlier,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,26 @@ pieces of doctrine that came out of the same app.
   predecessor under the encoding it was published with. Scoped to contracts —
   `DelegateLineageEntry` stores the full `delegate_key` and the walk never
   re-derives it, so the delegate registry does not have this hazard.
+- **Excluding a marker from an export is an explicit predicate, not a
+  placement.** River keeps its markers in the ordinary key space and filters
+  them on both the fetch and the import path, because a predecessor read by key
+  enumeration has no export prefix to hide behind. Also notes that markers
+  carried inside an export consume `HOST_ENUMERATION_CAP`, and restores the
+  "mint the ids as hex" instruction that the rewrite had reduced to "ASCII at
+  the boundary".
+- **Sealing needs a precondition the skill only stated in one of its two
+  homes.** A definitive answer is necessary and not sufficient: the prior
+  question is whether the predecessor store is genuinely frozen after the
+  re-key. Added beside the placement material and beside `fetch_secrets`.
+- **`SeedLocal` no longer appears in `contract-patterns.md`'s "may seal"
+  list.** It contradicted a paragraph twelve lines above it in the same file,
+  and the `freenet-app-migration` skill that owns the rule. `freenet-migrate`
+  0.6.0 settles it: *"`Outcome::SeedLocal` deliberately does not claim to be
+  sealable"* (`src/driver.rs:160`). Pre-existing since 1.33.0.
+- **`contract-patterns.md`'s registry description said contract rows carry
+  "the params bytes used to derive the key".** They do not, which is the whole
+  premise of the new parameter rule. Corrected, with the warning placed on the
+  backward-probe recipe itself rather than only in `upgrade-and-migration.md`.
 - **NEW: `Ok(vec![])` is a positive claim and seals a predecessor
   permanently.** An empty-success answer from `fetch_secrets` is
   indistinguishable from "nothing was there" and writes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,10 @@ engineer into.
   (Harvest's `seal_decision`). The remedy is a source pin kept *alongside* the
   behavioural test — otherwise the general warning about source pins gets
   applied to the one case where a source pin is correct.
-- **Never put a contract migration marker in the delegate.** It is the obvious
+- **Never put a contract migration marker in the delegate.**
+  **(SUPERSEDED in 1.35.0 — this rule was wrong. `localStorage` throws at
+  the opaque origin a published webapp runs at; the delegate's secret store
+  is the right home. See the 1.35.0 entry.)** It is the obvious
   home and it is wrong: the marker is lost when the *delegate* re-keys, which
   silently resets every contract marker at exactly the moment the contracts
   re-keyed too. Browser `localStorage`, hex-encoded, keyed by artifact +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.35.0 (2026-09-04)
+
+Resolves the blocking review finding on 1.34.0's marker rule, and adds two
+pieces of doctrine that came out of the same app.
+
+- **Marker placement, corrected.** 1.34.0 said to keep a contract migration
+  marker in browser `localStorage`. That does not work in the environment this
+  skill targets: the gateway serves a webapp in an iframe whose `sandbox` omits
+  `allow-same-origin`, so the app frame has an opaque origin and
+  `localStorage` throws. It fails *safe* — unreadable reads as "not migrated",
+  so the walk repeats rather than being skipped — which is why the bug was
+  silent in a real app until the sandbox attribute was re-read. The delegate's
+  secret store is the only durable client store a Freenet webapp has, and
+  1.34.0's "never keep a contract marker in the delegate" is withdrawn.
+- **The real question is whether the marker travels with a delegate export**,
+  and it turns on what the marker *names*. A marker naming a predecessor
+  **delegate** must not travel — copying it forward forges migration state for
+  the successor (River). A marker naming a **contract** generation should
+  travel — a delegate re-key does not change that fact (Harvest puts its
+  markers inside the exported prefix deliberately). Written as a table with the
+  deciding question, plus ghostkeys' third case (no durable marker at all), and
+  the note that the crate's own `PRED_DONE_MARKER_KEY_PREFIX` markers are not a
+  substitute. `contract-patterns.md`'s delegate-KV recipe and
+  `delegate-patterns.md`'s opaque-origin note now agree with it and point at it.
+- **A delegate marker request takes an id, not a raw storage key.** The
+  delegate prepends its own namespace, so nothing the caller sends can name a
+  key outside it. The same secret store holds private keys, so a raw-key write
+  would let a migration note overwrite an RSA private key — a general hazard
+  for any delegate with a shared secret namespace.
+- **NEW: a parameter-struct change is itself a migration, and the lineage
+  cannot express it.** A contract's address is
+  `BLAKE3(code_hash ‖ parameter_bytes)`, but `ContractLineageEntry` carries only
+  a code hash and `predecessor_ids(params, lineage)` maps the *current* build's
+  parameter bytes over every entry. So editing a parameter struct orphans every
+  instance ever published, and the probe reports a clean "nothing to migrate"
+  with green tests, green CI and no runtime symptom. Remedy: a frozen
+  generation boundary and a frozen copy of the old struct, deriving each
+  predecessor under the encoding it was published with. Scoped to contracts —
+  `DelegateLineageEntry` stores the full `delegate_key` and the walk never
+  re-derives it, so the delegate registry does not have this hazard.
+- **NEW: `Ok(vec![])` is a positive claim and seals a predecessor
+  permanently.** An empty-success answer from `fetch_secrets` is
+  indistinguishable from "nothing was there" and writes a
+  `Done { had_data: false }` marker that is never revisited; the crate's own
+  words are "the cost of a wrong `Err` is one retry, the cost of a wrong
+  `Ok(vec![])` is the user's data". Placed beside the forward-only section,
+  with the generalisation: silence and absence must stay distinguishable at the
+  type level, because only one of them may seal.
+
 ## 1.34.0 (2026-09-04)
 
 Seven corrections from actually adopting `freenet-migrate` in a live app

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -517,6 +517,17 @@ in `NodeDiagnosticsResponse`, hardened wire-boundary enums with
 `DEFAULT_NONCE` constants, so you need the wildcard match arms / random
 cipher generation documented in `references/delegate-patterns.md`.
 
+`DEFAULT_CIPHER`/`DEFAULT_NONCE` is the break that gets quoted, but it is
+**not the only one**. `ContractInstanceId::from_bytes` is deprecated in
+0.8 in favour of `from_base58` — it is a delegating alias, so it still
+compiles, but a crate built with `-D warnings` (most CI) fails on it. Note
+what the rename is telling you: it parses base58 **text**, not raw bytes.
+If you were passing it a raw 32-byte id it was already wrong; the
+replacement there is `ContractInstanceId::new([u8; 32])`, not
+`from_base58`. Budget a compile-and-read pass over the deprecation
+warnings rather than assuming a single documented break is the whole
+list.
+
 ```toml
 # Workspace-wide (Cargo.toml) — matches River pin.
 freenet-stdlib = { version = "0.8.5", features = ["contract"] }
@@ -579,6 +590,11 @@ must now generate random values per session — e.g.
 `let key: [u8; 32] = rand::random(); let nonce: [u8; 24] = rand::random();`.
 Code still referencing the old constants will fail to compile against
 stdlib 0.8 or newer.
+
+It is not the only 0.6→0.8 break, and treating it as the whole list is how
+a `-D warnings` build fails after the port looks finished — see the
+version-pinning section above for `ContractInstanceId::from_bytes` →
+`from_base58`.
 
 ---
 

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -291,7 +291,7 @@ Determine what private data each user needs stored locally and split it across d
 2. Implement `DelegateInterface` trait
 3. Handle secret storage operations (Store, Get, Delete, List)
 4. Implement cryptographic operations (signing, encryption)
-5. **Design for secret migration from v1** -- when delegate WASM changes, the delegate key changes and all stored secrets become inaccessible. There is **no `ExportSecrets` handler** (an earlier misconception): River's real mechanism messages each old delegate key via `DelegateRequest::ApplicationMessages`, re-running the old WASM to read its secrets, and folds the signing keys forward (encryption secrets are re-derived). Keep a committed registry of old delegate keys and migrate promptly — the re-run breaks after a stdlib/ABI bump (freenet/river#204). See delegate-patterns.md for the mechanism; `freenet-migrate` codifies the delegate registry and build codegen, but delegate secret carry-forward has no core mechanism and never will — a node-level attempt (`RegisterDelegateWithPredecessors`) was built, shipped, then found forgeable and disabled as a security fix (freenet-core#5199), and after three rejected trust-model designs, app-level migration is settled standing policy, not an interim measure. App-level does not mean bespoke: `freenet-migrate` ships the delegate-side entry points (`migrate_delegate_secrets`, `register_delegate_with_migration`, unchanged since 0.5.0; crates.io is now 0.6.0, whose break is contract-half only), and River, Delta and ghostkeys all drive them on `main` at 0.5.0. Note that River and Delta run the crate's walk *alongside* their existing hand-rolled sweep, which stays authoritative for now; retiring the sweep is a later release, after the walk field-validates. See delegate-patterns.md → "Delegate secret migration: no core mechanism, and why" for the full history, the `freenet-migrate-adoption` skill for the swap procedure, and freenet-core#2776 for live status. See `upgrade-and-migration.md` for the operational discipline (resumable/interrupted-migration recovery, migration telemetry, and the upgrade test harness).
+5. **Design for secret migration from v1** -- when delegate WASM changes, the delegate key changes and all stored secrets become inaccessible. There is **no `ExportSecrets` request in the stdlib wire protocol** and no node-level copy-forward. The mechanism messages each old delegate key via `DelegateRequest::ApplicationMessages`, re-running the old WASM to read its secrets, and folds the signing keys forward (encryption secrets are re-derived) — so **only a predecessor whose already-deployed WASM answers can be recovered from**, which makes this forward-only. `freenet-migrate` ships that answer as `handle_export_request` (since 0.3.0) for you to call from your delegate; River needs no *special* handler only because its chat delegate already answered a general-purpose `GetRequest`/`ListRequest` over its own secret namespace, which most delegates do not. Every release shipped without an export answer adds one permanently unrecoverable generation — see delegate-patterns.md → "A delegate migration is forward-only". Keep a committed registry of old delegate keys and migrate promptly — the re-run breaks after a stdlib/ABI bump (freenet/river#204). See delegate-patterns.md for the mechanism; `freenet-migrate` codifies the delegate registry and build codegen, but delegate secret carry-forward has no core mechanism and never will — a node-level attempt (`RegisterDelegateWithPredecessors`) was built, shipped, then found forgeable and disabled as a security fix (freenet-core#5199), and after three rejected trust-model designs, app-level migration is settled standing policy, not an interim measure. App-level does not mean bespoke: `freenet-migrate` ships the delegate-side entry points (`migrate_delegate_secrets`, `register_delegate_with_migration`, unchanged since 0.5.0; crates.io is now 0.6.0, whose break is contract-half only), and River, Delta and ghostkeys all drive them on `main` at 0.5.0. Note that River and Delta run the crate's walk *alongside* their existing hand-rolled sweep, which stays authoritative for now; retiring the sweep is a later release, after the walk field-validates. See delegate-patterns.md → "Delegate secret migration: no core mechanism, and why" for the full history, the `freenet-migrate-adoption` skill for the swap procedure, and freenet-core#2776 for live status. See `upgrade-and-migration.md` for the operational discipline (resumable/interrupted-migration recovery, migration telemetry, and the upgrade test harness).
 
 Reference: `references/delegate-patterns.md`
 
@@ -518,9 +518,12 @@ in `NodeDiagnosticsResponse`, hardened wire-boundary enums with
 cipher generation documented in `references/delegate-patterns.md`.
 
 `DEFAULT_CIPHER`/`DEFAULT_NONCE` is the break that gets quoted, but it is
-**not the only one**. `ContractInstanceId::from_bytes` is deprecated in
-0.8 in favour of `from_base58` — it is a delegating alias, so it still
-compiles, but a crate built with `-D warnings` (most CI) fails on it. Note
+**not the only one**. `ContractInstanceId::from_bytes` is deprecated as of
+**0.8.5** in favour of `from_base58` — it is a delegating alias, so it still
+compiles, but a crate built with `-D warnings` (most CI) fails on it. Check
+the version before acting on this: `from_base58` does not exist in 0.8.2,
+0.8.3 or 0.8.4, so a port that stops short of 0.8.5 sees no warning and has
+nothing to change. Note
 what the rename is telling you: it parses base58 **text**, not raw bytes.
 If you were passing it a raw 32-byte id it was already wrong; the
 replacement there is `ContractInstanceId::new([u8; 32])`, not
@@ -591,10 +594,10 @@ must now generate random values per session — e.g.
 Code still referencing the old constants will fail to compile against
 stdlib 0.8 or newer.
 
-It is not the only 0.6→0.8 break, and treating it as the whole list is how
-a `-D warnings` build fails after the port looks finished — see the
-version-pinning section above for `ContractInstanceId::from_bytes` →
-`from_base58`.
+It is not the only break on the way to current stdlib, and treating it as the
+whole list is how a `-D warnings` build fails after the port looks finished —
+see "Key Dependencies" above for `ContractInstanceId::from_bytes` →
+`from_base58` (0.8.5).
 
 ---
 

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -850,7 +850,12 @@ The recipe:
 2. **Record per-identity which contract hash that user's state lives
    under**, on the *delegate* (not on-chain) — e.g. an
    `AliasInfo { inbox_wasm_hash: Option<String>, … }` on the identity
-   delegate, persisted client-side.
+   delegate, persisted client-side. The delegate is the right home and the
+   only durable one: a published webapp runs at an opaque origin where
+   `localStorage` throws. Two placement rules come with it — whether the
+   marker travels with a delegate export, and never letting the client
+   choose the raw storage key. Both are in `upgrade-and-migration.md`,
+   property 2; read them before adding a marker.
 3. **Maintain an append-only `LEGACY_*_CODE_HASHES` slice**, ordered
    oldest → newest, listing every prior `INBOX_CODE_HASH` the project
    has shipped.
@@ -867,7 +872,9 @@ The recipe:
    on the delegate BEFORE dispatching GETs; clear it only when the PUT
    under the current key succeeds. If the session ends before any GET
    resolves (offline, browser crash, gateway hiccup), the next session
-   sees the marker and re-attempts.
+   sees the marker and re-attempts. This marker names a **contract**
+   generation, so it is one that should be carried forward on a delegate
+   export — see the placement table in `upgrade-and-migration.md`.
 7. **Backwards-compat the delegate state** so old UI versions can read
    the new fields: every new field on `AliasInfo` is
    `#[serde(default)]`.
@@ -915,7 +922,7 @@ copy:
 |---|---|---|
 | Who triggers the migration | Any updated client; owner also writes pointer | The state's signer, in their own UI |
 | Where the legacy list lives | Embedded in WASM (read via build.rs from `legacy_contracts.toml`) | A Rust `const &[&str]` slice in the UI |
-| Recovery if a hop fails mid-flight | Pointer is permanent on-chain | `pending_migration_from` marker on delegate |
+| Recovery if a hop fails mid-flight | Pointer is permanent on-chain | `pending_migration_from` marker in the delegate's secret store |
 | Works for per-user state with no shared owner | Pointer half doesn't apply; probe half does | Yes |
 | Works for shared-room / single-owner state | Yes | Yes (probe needs no owner) |
 

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -819,7 +819,8 @@ the table:
 - **Registry inside the graph, but `#[cfg]`-gated off the contract builds.**
   Right when an outside integrator builds against the crate and needs the table
   (the case above, where placement and the invariant pull apart). River does
-  this: `river-core` code-generates `legacy_room_contracts.toml` and the
+  this: `river-core` code-generates `legacy_room_contracts.rs` from the
+  checked-in `legacy_room_contracts.toml`, and the
   room-contract depends on `river-core`, but the generated module sits behind
   `#[cfg(feature = "migration")]`, which the contract and delegate WASM builds
   do not enable — so the registry is reachable from crates.io and `riverctl`
@@ -987,11 +988,18 @@ the driver.** `migrate_contract` is a thin async wrapper that awaits a
 anything with awaitable request/response correlation. A Rust browser app on
 stdlib's `WebApi` has none: it delivers every response to a single
 app-registered handler, so a request and its answer are not connected by
-anything the language can await, and correlation is the app's job. (Check your
-client before assuming: the TypeScript `FreenetWsApi` is promise-based per
-request, so a TS UI does not face the *correlation* problem — though
-`migrate_contract` is a Rust crate function with no JavaScript binding, so a
-plain TS app writes the same loop itself either way.) There, construct
+anything the language can await, and correlation is the app's job. (A TS UI is not simply
+exempt. The TypeScript `FreenetWsApi` returns a promise per request, but it
+correlates by **FIFO queue position, not contract id** — `resolveNext` is a
+`queue.shift()` (`websocket-interface.ts:899-905`) — so it is only correct with
+one GET outstanding. And it **rejects** on `NotFound`
+(`new Error("Contract not found")`, `:769`) exactly as it rejects on a deadline
+(`new Error("Request timeout")`, `:890`), so `Absent` and `Unknown` arrive in the
+same shape, separable only by matching an error string. The idiomatic
+`try { await get() } catch { /* nothing there */ }` is the data-loss default the
+next section forbids. A TS app must rebuild that distinction itself before it can
+decide anything — and `migrate_contract` is a Rust crate function with no
+JavaScript binding, so it writes the loop either way.) There, construct
 `ProbeDriver` directly and pump it
 by hand: `next_action()` → send the GET and arm a timeout → feed the result back
 through `on_response` / `on_absent` / `on_unknown` (an expired timer is

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -709,7 +709,10 @@ contract, or the merge won't converge, and migration silently fails.
 The mechanism River (freenet/river#292) and Delta actually ship — and the one to
 build by default — is a **backward probe from a committed registry of past code
 hashes**. For each predecessor generation you reconstruct its key from
-`BLAKE3(BLAKE3(old_wasm) || stable_params)`, GET the old state, fold it forward,
+`BLAKE3(BLAKE3(old_wasm) || params)` — where `params` must be the bytes **that
+generation was published under**, which is not automatically today's encoding;
+see `upgrade-and-migration.md` → "A parameter-struct change is a migration too".
+GET the old state, fold it forward,
 and re-PUT it under the current key (the successor's `validate_state` re-verifies
 every byte, so any client may do it — the owner need not be online). The registry
 is a committed TOML walked newest→oldest; this is written up in full under "the
@@ -761,9 +764,21 @@ old contract's state and follow it.
 ### Register old WASM hashes in a migration file
 
 Maintain a file like `legacy_contracts.toml` (analogous to
-`legacy_delegates.toml` for delegates) listing every historical contract WASM hash
-plus the params bytes used to derive its key. The `build.rs` generates a Rust
-`const` array from it; the runtime probes each old key at startup.
+`legacy_delegates.toml` for delegates) listing every historical contract WASM
+hash. The `build.rs` generates a Rust `const` array from it; the runtime probes
+each old key at startup.
+
+**A contract row records the code hash and nothing else** — `freenet-migrate`'s
+`ContractLineageEntry` is `{ generation, code_hash, note }`, and
+`predecessor_ids(params, lineage)` maps *one* set of parameter bytes over every
+row. So the registry cannot express a parameter change, and a parameter edit
+orphans every published instance while the probe reports a clean "nothing to
+migrate". If your parameters have ever changed shape, you must derive each
+generation under its own encoding yourself — see `upgrade-and-migration.md` → "A
+parameter-struct change is a migration too". (The delegate rows do not have this
+problem: `DelegateLineageEntry` stores the full `delegate_key`, the walk never
+re-derives it, and the registry row carries an optional `params_hex` that the
+build-time cross-check honours.)
 
 **Placement follows whoever runs the sweep. Ask "who probes?", not "where do
 registries go?"** Put the registry in whatever crate the probing code is built from.
@@ -1022,9 +1037,15 @@ write.
 "protects exhaustive matches only"), so **a wildcard arm that defaults to "done"
 writes a permanent marker wrongly** — for today's non-definitive variants and for
 every variant added later. May seal: `Recovered` with no unresolved candidates and
-no truncated fold; `SeedLocal`. Must NOT seal: `Indeterminate`, `Recovered` with
-unresolved candidates or a truncated fold, any error, and any variant the `match`
-did not name. Name the sealing variants explicitly and let the wildcard fall
+no truncated fold — that is the one *positive* result, where you found the data
+and know the search was complete. Must NOT seal: `Indeterminate`, `Recovered`
+with unresolved candidates or a truncated fold, any error, and any variant the
+`match` did not name. **`SeedLocal` must not seal either**, however conclusive an
+all-`Absent` walk looks. The crate says so itself: *"`Outcome::SeedLocal`
+deliberately does not claim to be sealable"*
+(`freenet-migrate-0.6.0/src/driver.rs:160`), because `Absent` is unauthenticated
+— see the paragraph above. Seeding your local snapshot forward on `SeedLocal` is
+still fine; that is not the same act as sealing. Name the sealing variants explicitly and let the wildcard fall
 through to "retry next run".
 
 **Probe unconditionally per `(instance, current_code_hash)`, before anything writes

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -989,7 +989,10 @@ stdlib's `WebApi` has none: it delivers every response to a single
 app-registered handler, so a request and its answer are not connected by
 anything the language can await, and correlation is the app's job. (Check your
 client before assuming: the TypeScript `FreenetWsApi` is promise-based per
-request, so a TS UI *does* have the correlation and can use the wrapper.) There, construct `ProbeDriver` directly and pump it
+request, so a TS UI does not face the *correlation* problem — though
+`migrate_contract` is a Rust crate function with no JavaScript binding, so a
+plain TS app writes the same loop itself either way.) There, construct
+`ProbeDriver` directly and pump it
 by hand: `next_action()` → send the GET and arm a timeout → feed the result back
 through `on_response` / `on_absent` / `on_unknown` (an expired timer is
 `on_unknown`) → `take_outcome()` at `Step::Done`. The crate documents this on

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -785,24 +785,36 @@ apps are granted `{ReadPublic, Sign}` and never `Export`
 would hand them a table they are incapable of using. `ghostkey-common 0.3.0` therefore
 ships no registry, and that is correct rather than a gap.
 
-**"Who probes?" orients the choice; this constraint vetoes it. Never
-code-generate a registry from a crate that is inside the contract build graph.**
-If the crate holding the registry compiles into the contracts, then editing the
-registry changes the contract WASM — so recording a migration re-keys every
-contract that registry describes, and you have built a registry that *causes*
-the migration it exists to record. Decide it from the dependency direction, not
-from which crate is named "common" or "shared": in the Harvest marketplace
-`harvest-common` compiles into all three contracts and the delegate while
-`harvest-ui` compiles into none, so the UI crate is the only safe home for the
-codegen even though both are shared crates. Check by asking what a one-line
-registry edit rebuilds — `cargo tree --invert` from the candidate crate answers
-it — before you put a `build.rs` there.
+**"Who probes?" orients the choice; this invariant constrains it. A one-line
+registry edit must not change the contract WASM bytes.** Otherwise recording a
+migration re-keys the very contracts the registry describes, and you have built
+a registry that *causes* the migration it exists to record. The hazard is real
+and easy to walk into, because the registry's natural home — the shared "common"
+crate — is usually the one that compiles into the contracts.
 
-When the two pull in different directions (an outside integrator needs the table,
-but the crate they build from is in the contract graph) the constraint wins: it
-is a correctness property, while placement is a convenience. Split the registry
-into a crate the contracts do not depend on, or publish it as data the consumer
-reads at their own build time.
+Two shapes satisfy the invariant, and which one you want depends on who needs
+the table:
+
+- **Registry in a crate outside the contract build graph.** Simplest, and right
+  when only your own UI probes. In the Harvest marketplace `harvest-common`
+  compiles into all three contracts and the delegate while `harvest-ui` compiles
+  into none, so the codegen lives in `harvest-ui/build.rs` even though both are
+  shared crates. Decide from the dependency direction, not from which crate is
+  named "common".
+- **Registry inside the graph, but `#[cfg]`-gated off the contract builds.**
+  Right when an outside integrator builds against the crate and needs the table
+  (the case above, where placement and the invariant pull apart). River does
+  this: `river-core` code-generates `legacy_room_contracts.toml` and the
+  room-contract depends on `river-core`, but the generated module sits behind
+  `#[cfg(feature = "migration")]`, which the contract and delegate WASM builds
+  do not enable — so the registry is reachable from crates.io and `riverctl`
+  while the contract bytes never see it.
+
+**Verify it, don't infer it.** `cargo tree --invert` tells you crate edges, not
+whether bytes moved, and it would wrongly condemn River's arrangement. The test
+is the artifact: edit the registry, rebuild, and `b3sum` the contract and
+delegate WASM against the pre-edit hashes. That is the property you actually
+need, and it is the same pre-publish hash check the next section describes.
 
 ### Pre-publish check
 
@@ -950,10 +962,12 @@ bounds the walk.
 **Which entry point you use is an environment question, and a browser app needs
 the driver.** `migrate_contract` is a thin async wrapper that awaits a
 `ProbeIo::get` per candidate — right for a CLI, a bridge, a test harness, or
-anything with awaitable request/response correlation. A browser app has none:
-`WebApi` delivers every response to a single app-registered handler, so a request
-and its answer are not connected by anything the language can await, and
-correlation is the app's job. There, construct `ProbeDriver` directly and pump it
+anything with awaitable request/response correlation. A Rust browser app on
+stdlib's `WebApi` has none: it delivers every response to a single
+app-registered handler, so a request and its answer are not connected by
+anything the language can await, and correlation is the app's job. (Check your
+client before assuming: the TypeScript `FreenetWsApi` is promise-based per
+request, so a TS UI *does* have the correlation and can use the wrapper.) There, construct `ProbeDriver` directly and pump it
 by hand: `next_action()` → send the GET and arm a timeout → feed the result back
 through `on_response` / `on_absent` / `on_unknown` (an expired timer is
 `on_unknown`) → `take_outcome()` at `Step::Done`. The crate documents this on

--- a/skills/dapp-builder/references/contract-patterns.md
+++ b/skills/dapp-builder/references/contract-patterns.md
@@ -785,6 +785,25 @@ apps are granted `{ReadPublic, Sign}` and never `Export`
 would hand them a table they are incapable of using. `ghostkey-common 0.3.0` therefore
 ships no registry, and that is correct rather than a gap.
 
+**"Who probes?" orients the choice; this constraint vetoes it. Never
+code-generate a registry from a crate that is inside the contract build graph.**
+If the crate holding the registry compiles into the contracts, then editing the
+registry changes the contract WASM — so recording a migration re-keys every
+contract that registry describes, and you have built a registry that *causes*
+the migration it exists to record. Decide it from the dependency direction, not
+from which crate is named "common" or "shared": in the Harvest marketplace
+`harvest-common` compiles into all three contracts and the delegate while
+`harvest-ui` compiles into none, so the UI crate is the only safe home for the
+codegen even though both are shared crates. Check by asking what a one-line
+registry edit rebuilds — `cargo tree --invert` from the candidate crate answers
+it — before you put a `build.rs` there.
+
+When the two pull in different directions (an outside integrator needs the table,
+but the crate they build from is in the contract graph) the constraint wins: it
+is a correctness property, while placement is a convenience. Split the registry
+into a crate the contracts do not depend on, or publish it as data the consumer
+reads at their own build time.
+
 ### Pre-publish check
 
 Add a preflight task that fails if the contract WASM hash has changed from the
@@ -927,6 +946,22 @@ freenet/river#427). The decisions: newest generation first by the registry
 generation field, first real state wins, an undecodable or placeholder response is
 a miss and advances the walk, late responses are single-shot ignored, and a hop cap
 bounds the walk.
+
+**Which entry point you use is an environment question, and a browser app needs
+the driver.** `migrate_contract` is a thin async wrapper that awaits a
+`ProbeIo::get` per candidate — right for a CLI, a bridge, a test harness, or
+anything with awaitable request/response correlation. A browser app has none:
+`WebApi` delivers every response to a single app-registered handler, so a request
+and its answer are not connected by anything the language can await, and
+correlation is the app's job. There, construct `ProbeDriver` directly and pump it
+by hand: `next_action()` → send the GET and arm a timeout → feed the result back
+through `on_response` / `on_absent` / `on_unknown` (an expired timer is
+`on_unknown`) → `take_outcome()` at `Step::Done`. The crate documents this on
+`migrate_contract` itself, and the two make identical decisions by construction —
+the wrapper is a loop over the same machine. Hand-pumping earns its keep even
+where a wrapper would compile: it puts the sequencing in code `cargo test` runs
+on the host, leaving only "send a GET, arm a timer, route a response" behind the
+wasm gate.
 
 **Silence is not absence.** This is the 0.6.0 break (freenet-migrate#19), and it is
 the whole reason to be on 0.6.0. Your adapter's `ProbeIo::get` returns a three-way

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -882,8 +882,11 @@ answer will.** The crate ships that answer as `handle_export_request`, called
 from your delegate: it authorizes the caller's origin, enumerates the requested
 secret scope generically via `SecretStore::list_secrets`, and packages the result
 into an outbound `ApplicationMessage`. A predecessor built before you added it
-rejects the request, so the walk records `PredecessorMigration::Unresponsive` —
-forever. Those secrets are then **permanently unrecoverable**: delegate secrets
+rejects the request, so the walk records `PredecessorMigration::Unresponsive`
+every time it runs. That record is not itself permanent — an unresponsive
+predecessor earns no marker and is re-walked on the next load, which is the
+correct behaviour. What is permanent is that the re-walk can never succeed, so
+those secrets are **unrecoverable**: delegate secrets
 are node-local (`secrets_dir/<delegate-key>/`, encrypted under the node's own
 KEK, never replicated), so there is no second copy to recover from, and nothing
 you write on the client reaches WASM that is already published.

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -833,8 +833,13 @@ addresses the predecessor's key while presenting `MessageOrigin::WebApp` — whi
 is stable across a delegate re-key. Do not reach for `OriginPolicy::FromDelegate`
 by analogy; River's own `check_origin` rejects delegate-to-delegate calls
 outright. A delegate whose `handle_request` accepts only its
-app's typed requests — the common case — can answer nothing a successor asks, and
-no client-side change alters that, because the old WASM is already deployed. Read
+app's typed requests — the common case — can answer only those, and no
+client-side change alters that, because the old WASM is already deployed. That
+is sometimes enough: if the typed protocol exposes every key you need and the
+key set is fixed, the successor's UI can send the predecessor's own requests to
+the old key and recover the lot. It is not enough the moment a key family is
+dynamic and unguessable, which is what an enumeration or export handler is for —
+and you cannot add one retroactively. Read
 "A delegate migration is forward-only" below **before** you plan a migration; it
 changes when you adopt, not just how.
 

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -927,7 +927,7 @@ The forward-only case above is the *benign* one: a predecessor that cannot
 answer is classified `Unresponsive`, earns no marker, and is re-walked next
 load. The damaging case is the successor's own adapter answering on its behalf.
 
-`SecretsMigrationIo::fetch_secrets` is three-valued in effect, and only two of
+`PredecessorSecretsIo::fetch_secrets` is three-valued in effect, and only two of
 the three are visible in the type. `Ok(pairs)` and `Ok(vec![])` both mean **"I
 asked, and this is what it has"** — an empty vector seals the predecessor with a
 `Done { had_data: false }` marker that is never revisited. Return it for a
@@ -945,22 +945,21 @@ an undecodable reply, an answered error. It is not an abort: the driver records
 `PredecessorMigration::Unresponsive`, the walk continues or stops per
 `SecretSelectionPolicy`, and `migrate_delegate_secrets` still returns a report.
 
-The rule generalises past this one call. Wherever a migration adapter converts
-an I/O result into an answer, **silence and absence must stay distinguishable at
-the type level**, because only one of them may seal:
+This is one instance of the general rule stated under `upgrade-and-migration.md`
+property 2 and applied to `ProbeAnswer` in `contract-patterns.md`: **silence and
+absence must stay distinguishable at the type level, because only one of them may
+seal.** Make the third value an explicit variant rather than an `Option` that
+collapses two of them, route "no usable answer" to retry, and do the reduction in
+a pure function so each arm can be mutated red in a test.
 
-- Make the third value explicit — a three-variant enum (present / definitively
-  absent / no usable answer), not an `Option` that collapses two of them.
-- Route "no usable answer" to the retry path, never the seal path. Only a
-  *definitive* answer may write a durable marker.
-- Do the reduction in a pure function so it is testable without the I/O, and
-  mutate each arm to confirm the test is actually red.
-
-River's adapter overrides the crate's own recommended semantics for exactly this
-reason (`delegate_migration.rs`, constraint 1: "a timeout is not an absence"),
-and Harvest's `migrate::probe_gate` is the same shape on the client side.
-ghostkeys went further and made its markers page-lifetime only, because in its
-case even a definitive-looking answer could be invalidated by a late arrival.
+A definitive answer is *necessary* to seal and not *sufficient*. The prior
+question is whether the predecessor store is genuinely frozen after the re-key —
+if anything can still write to a predecessor, a durable marker strands whatever
+arrives after it. River seals because its legacy delegates are frozen and
+overrides the crate's recommended semantics to do so safely
+(`delegate_migration.rs`, constraint 1: "a timeout is not an absence"); ghostkeys
+bans durable markers outright. Harvest's `migrate::probe_gate` is the same shape
+on the client side.
 
 ### Preconditions
 

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -823,8 +823,13 @@ loads and runs that old WASM, and whatever handler it shipped with answers.
 **"Whatever handler it shipped with" is the whole constraint, and it is easy to
 read past.** River's predecessors need no *special* export handler only because
 River's chat delegate already answered a general-purpose `GetRequest` /
-`ListRequest` over its own secret namespace, so a successor can enumerate through
-the app's ordinary protocol. A delegate whose `handle_request` accepts only its
+`ListRequest` over its own secret namespace, so the new generation can enumerate
+through the app's ordinary protocol. Note who is calling: the crate is sans-IO
+and the *app* owns both ends of the round-trip, so it is River's UI that
+addresses the predecessor's key while presenting `MessageOrigin::WebApp` — which
+is stable across a delegate re-key. Do not reach for `OriginPolicy::FromDelegate`
+by analogy; River's own `check_origin` rejects delegate-to-delegate calls
+outright. A delegate whose `handle_request` accepts only its
 app's typed requests — the common case — can answer nothing a successor asks, and
 no client-side change alters that, because the old WASM is already deployed. Read
 "A delegate migration is forward-only" below **before** you plan a migration; it
@@ -889,14 +894,20 @@ load-bearing at the call site:
 
 - **Fail closed on an unattested caller.** `OriginPolicy::authorize` rejects
   `origin: None` — which the runtime supplies when it cannot attest who is
-  asking. These are private keys; guessing is not an option.
+  asking — under every policy *except* `OriginPolicy::Any`, which accepts it and
+  is documented as unsafe / local-testing only. Never ship `Any`. These are
+  private keys; guessing is not an option.
 - **Export by prefix unless the delegate genuinely serves one web app.** A
   delegate's secret namespace is shared by every app using it and the host does
   not slice it per origin, so a whole-scope export hands the requester
   everything. The crate gates that behind
   `SingleAppDelegateAck::i_certify_this_delegate_serves_a_single_web_app()`.
-  `ExportScope::Prefix` costs nothing and stays correct if the delegate later
-  serves more than one app.
+  `ExportScope::Prefix` narrows what you hand over and stays correct if the
+  delegate later serves more than one app. It does not, however, buy you a
+  smaller enumeration: `export_scoped` calls `list_secrets(b"")` on every
+  export, prefix or not, because cap saturation is a whole-scope property — so a
+  prefix export is refused by the truncation check below on exactly the same
+  terms as a whole-scope one.
 
 Two residual limits no handler fixes, worth knowing before you rely on an
 export. The host caps key enumeration per scope (`HOST_ENUMERATION_CAP`, 4096)
@@ -978,7 +989,8 @@ see the next section for the full history and current guidance.
 **Adopting them is not retroactive.** The walk can only recover from a
 predecessor whose deployed WASM answers — see "A delegate migration is
 forward-only" above. That is an argument for adopting the crate *before* you
-need it, and the reason it appears above the mechanics rather than below them.
+need it: the handler does nothing on the day it lands, and everything for the
+re-key after that.
 
 For the call-site swap itself in an app that already hand-rolls a sweep, see the
 `freenet-migrate-adoption` skill.

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -814,10 +814,21 @@ Delegates store secrets (signing keys, user data) keyed by delegate key. A new W
 
 ### How migration actually works: re-run the old delegate
 
-There is **no `ExportSecrets` request handler** — earlier versions of this doc
-described one, but River ships nothing of the kind. The real mechanism (River's,
-and Delta's) is a **backward probe that re-runs the old delegate's own WASM**;
-the old delegate needs no special export handler.
+There is **no `ExportSecrets` request in the stdlib wire protocol** and no
+node-level copy-forward (see "Delegate secret migration: no core mechanism, and
+why" below). The mechanism is a **backward probe that re-runs the old delegate's
+own WASM**: the successor addresses a message to the predecessor's key, the node
+loads and runs that old WASM, and whatever handler it shipped with answers.
+
+**"Whatever handler it shipped with" is the whole constraint, and it is easy to
+read past.** River's predecessors need no *special* export handler only because
+River's chat delegate already answered a general-purpose `GetRequest` /
+`ListRequest` over its own secret namespace, so a successor can enumerate through
+the app's ordinary protocol. A delegate whose `handle_request` accepts only its
+app's typed requests — the common case — can answer nothing a successor asks, and
+no client-side change alters that, because the old WASM is already deployed. Read
+"A delegate migration is forward-only" below **before** you plan a migration; it
+changes when you adopt, not just how.
 
 1. On startup the successor (new) delegate's UI walks a committed registry of
    every previous delegate key (see "Migration Entry Registry" below).
@@ -849,6 +860,52 @@ everything else.
 > entries were removed as unrecoverable — affected users had to rejoin via
 > invite. Migrate promptly (don't let a generation sit unmigrated across an
 > stdlib bump), and never assume an arbitrarily old WASM will still run.
+
+### A delegate migration is forward-only
+
+**Adopting `freenet-migrate` does not carry your app's existing delegate secrets
+forward. The successor *asks*; only a predecessor whose already-deployed WASM can
+answer will.** The crate ships that answer as `handle_export_request`, called
+from your delegate: it authorizes the caller's origin, enumerates the requested
+secret scope generically via `SecretStore::list_secrets`, and packages the result
+into an outbound `ApplicationMessage`. A predecessor built before you added it
+rejects the request, so the walk records `PredecessorMigration::Unresponsive` —
+forever. Those secrets are then **permanently unrecoverable**: delegate secrets
+are node-local (`secrets_dir/<delegate-key>/`, encrypted under the node's own
+KEK, never replicated), so there is no second copy to recover from, and nothing
+you write on the client reaches WASM that is already published.
+
+The consequence is a scheduling rule, not a coding one: **every release you ship
+without an export handler adds one more permanently unrecoverable generation.**
+The handler does nothing for anyone on the day it lands — its entire value is
+that the *next* re-key is survivable. So land it as early as you can, ideally
+long before you have any migration to do, and treat "we have nothing to migrate
+yet" as the argument for adopting sooner rather than a reason to defer. (Harvest
+adopted the crate at four already-deployed delegate generations. Those four are
+written off; generation five onwards is recoverable.)
+
+Two things the handler must get right, both of which the crate makes
+load-bearing at the call site:
+
+- **Fail closed on an unattested caller.** `OriginPolicy::authorize` rejects
+  `origin: None` — which the runtime supplies when it cannot attest who is
+  asking. These are private keys; guessing is not an option.
+- **Export by prefix unless the delegate genuinely serves one web app.** A
+  delegate's secret namespace is shared by every app using it and the host does
+  not slice it per origin, so a whole-scope export hands the requester
+  everything. The crate gates that behind
+  `SingleAppDelegateAck::i_certify_this_delegate_serves_a_single_web_app()`.
+  `ExportScope::Prefix` costs nothing and stays correct if the delegate later
+  serves more than one app.
+
+Two residual limits no handler fixes, worth knowing before you rely on an
+export. The host caps key enumeration per scope (`HOST_ENUMERATION_CAP`, 4096)
+and truncates silently, so `handle_export_request` **refuses** with
+`MigrateError::TruncatedExport` rather than shipping a partial set and then
+sealing a marker over it. And secrets written before the host gained its
+key-enumeration registry (freenet-core#4355) are not returned by
+`list_secrets` until they are rewritten — undetectable from inside the delegate,
+so touch such keys before relying on a whole-scope export.
 
 ### Preconditions
 
@@ -917,6 +974,11 @@ and `register_delegate_with_migration` (the `delegate_migrate` module) are the
 app-facing entry points, and River, Delta and ghostkeys all drive them on `main`
 at 0.5.0. Delegate secrets still have no core-level equivalent and never will;
 see the next section for the full history and current guidance.
+
+**Adopting them is not retroactive.** The walk can only recover from a
+predecessor whose deployed WASM answers — see "A delegate migration is
+forward-only" above. That is an argument for adopting the crate *before* you
+need it, and the reason it appears above the mechanics rather than below them.
 
 For the call-site swap itself in an app that already hand-rolls a sweep, see the
 `freenet-migrate-adoption` skill.

--- a/skills/dapp-builder/references/delegate-patterns.md
+++ b/skills/dapp-builder/references/delegate-patterns.md
@@ -754,7 +754,10 @@ const { delegate_key_bytes, code_hash_bytes } =
 This works from inside a sandboxed webapp: the gateway serves bundle files with
 `Access-Control-Allow-Origin: *`, and the sandbox CSP permits `connect-src` to
 the gateway origin. (Verified from an opaque-origin frame — `localStorage`
-throws there, and the fetch still returns 200.)
+throws there, and the fetch still returns 200.) That `localStorage` throws is
+not a footnote: it is why a Freenet webapp's durable client state, migration
+markers included, has to live in the delegate's secret store. See
+`upgrade-and-migration.md`, property 2.
 
 Three rules that matter:
 
@@ -917,6 +920,47 @@ sealing a marker over it. And secrets written before the host gained its
 key-enumeration registry (freenet-core#4355) are not returned by
 `list_secrets` until they are rewritten — undetectable from inside the delegate,
 so touch such keys before relying on a whole-scope export.
+
+### `Ok(vec![])` is a positive claim, and it seals permanently
+
+The forward-only case above is the *benign* one: a predecessor that cannot
+answer is classified `Unresponsive`, earns no marker, and is re-walked next
+load. The damaging case is the successor's own adapter answering on its behalf.
+
+`SecretsMigrationIo::fetch_secrets` is three-valued in effect, and only two of
+the three are visible in the type. `Ok(pairs)` and `Ok(vec![])` both mean **"I
+asked, and this is what it has"** — an empty vector seals the predecessor with a
+`Done { had_data: false }` marker that is never revisited. Return it for a
+request that merely went *unanswered* and you have recorded a slow, throttled or
+temporarily unreachable predecessor as permanently empty, silently, with the
+migration report reading complete. The crate says so in unusually flat terms:
+
+> the cost of a wrong `Err` is one retry, the cost of a wrong `Ok(vec![])` is the
+> user's data
+
+(`freenet-migrate 0.6.0`, `src/delegate_migrate.rs:417-436`.)
+
+So **`Err` is the right answer for silence** — a timeout, a transport failure,
+an undecodable reply, an answered error. It is not an abort: the driver records
+`PredecessorMigration::Unresponsive`, the walk continues or stops per
+`SecretSelectionPolicy`, and `migrate_delegate_secrets` still returns a report.
+
+The rule generalises past this one call. Wherever a migration adapter converts
+an I/O result into an answer, **silence and absence must stay distinguishable at
+the type level**, because only one of them may seal:
+
+- Make the third value explicit — a three-variant enum (present / definitively
+  absent / no usable answer), not an `Option` that collapses two of them.
+- Route "no usable answer" to the retry path, never the seal path. Only a
+  *definitive* answer may write a durable marker.
+- Do the reduction in a pure function so it is testable without the I/O, and
+  mutate each arm to confirm the test is actually red.
+
+River's adapter overrides the crate's own recommended semantics for exactly this
+reason (`delegate_migration.rs`, constraint 1: "a timeout is not an absence"),
+and Harvest's `migrate::probe_gate` is the same shape on the client side.
+ghostkeys went further and made its markers page-lifetime only, because in its
+case even a definitive-looking answer could be invalidated by a late arrival.
 
 ### Preconditions
 

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -125,7 +125,13 @@ The whole procedure, start to finish:
    `freenet-migrate` ships the delegate-side entry points
    (`migrate_delegate_secrets`, `register_delegate_with_migration`, unchanged
    since 0.5.0), and River, Delta and ghostkeys all drive them on `main` at
-   0.5.0. See `delegate-patterns.md` →
+   0.5.0. **A delegate migration is forward-only**: the successor asks, and only
+   a predecessor whose already-deployed WASM answers (in practice, one that
+   shipped `handle_export_request`, or an app protocol general enough to
+   enumerate its own secret namespace) can be recovered from. Every release
+   shipped without that handler adds one permanently unrecoverable generation,
+   which makes "we have no migration to do yet" the argument for adopting
+   sooner, not later. See `delegate-patterns.md` →
    "Delegate secret migration: no core mechanism, and why" for the full history
    and current guidance, and `contract-patterns.md` for the contract-side
    mechanics. For the procedure of swapping an existing hand-rolled sweep over
@@ -227,8 +233,9 @@ properties below are the whole game.
 
    ```rust
    // On migration start (before the first per-entity write):
-   set_flag("migration_in_progress");      // a localStorage / delegate key,
-                                           // namespaced per source-version set
+   set_flag("migration_in_progress");      // browser localStorage, NOT the
+                                           // delegate -- see below; namespaced
+                                           // per source-version set
    // ... write each entity via CAS ...
    // ONLY after every entity is written:
    clear_flag("migration_in_progress");
@@ -249,6 +256,23 @@ properties below are the whole game.
    definitive probe outcome. Never seal it because the destination *looks*
    populated: that is the empty-destination gate in disguise, and any earlier
    write then makes the migration permanently unreachable.
+
+   **Never keep a *contract* migration marker in the delegate.** The delegate is
+   the obvious home — it is already your durable client store, holding keys and
+   registries — and it is the wrong one, because a marker there is lost when the
+   **delegate** re-keys. That silently resets every contract marker at exactly the
+   moment the contracts re-keyed too, so the two failures arrive together and the
+   second one is invisible. Use browser `localStorage`, whose origin derives from
+   the web-container contract id and does not move when a data contract or a
+   delegate is rebuilt. Key it by `(artifact, instance, current_code_hash)` and
+   **hex-encode both ids**: raw bytes in a storage key alias under any lossy UTF-8
+   conversion, which is how two distinct 32-byte ids collapse onto one marker slot
+   and one of them gets sealed having never been migrated (River hit exactly that).
+   Make unreadable storage report **"not migrated"** — a private window, disabled
+   storage, or an embedding that denies access then costs one extra walk per page
+   load, which is wasteful and safe; reading it as "already done" skips the
+   migration entirely. Harvest's `ui/src/migrate.rs` (`marker_key` /
+   `migration_done`) is the worked shape.
 
 3. **Non-destructive.** Never delete the source until the destination is
    confirmed complete. Keep the old blob/keys as a rollback fallback so an old or
@@ -334,6 +358,21 @@ than burying it in async load code. River's `decide_per_room_load_action(bool)` 
 this pattern; its earlier source-pin-only test had a false positive (it passed
 even with the recovery call deleted), so prefer a pure-function behavioral test
 and verify by mutation that removing the fix fails the test.
+
+**When a guard provably cannot fail, a source-scrape pin is the right tool —
+and the only one.** Mutation testing asks you to name an input that turns the
+test red; some guards have none, and they are exactly the guards worth keeping.
+The canonical shape is the wildcard arm of a `match` over a `#[non_exhaustive]`
+enum: while every variant defined today is named explicitly, the wildcard is
+unreachable, so inverting it to the unsafe default leaves every behavioural test
+green. It is protecting against a variant a *future* release adds, which no input
+you can construct today reaches. Harvest hit this in `seal_decision`: inverting
+`_ => Seal::Retry` to `Seal::Seal` broke nothing. The remedy is not a better
+behavioural test — it is a test that reads the source and asserts the arm exists
+and returns the safe value, kept **alongside** the behavioural test rather than
+instead of it, with a comment saying why this one guard is pinned that way.
+Otherwise the earlier rule (a source pin is a false positive waiting to happen)
+gets applied to the one case where it is correct, and the pin is deleted.
 
 **Three questions worth asking of any migration change in review.** Each names a
 failure a green test suite let through.

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -131,9 +131,10 @@ The whole procedure, start to finish:
    enumerate its own secret namespace) can be recovered from. Every release
    shipped without that handler adds one permanently unrecoverable generation,
    which makes "we have no migration to do yet" the argument for adopting
-   sooner, not later. See `delegate-patterns.md` →
-   "Delegate secret migration: no core mechanism, and why" for the full history
-   and current guidance, and `contract-patterns.md` for the contract-side
+   sooner, not later. See `delegate-patterns.md` → "A delegate migration is
+   forward-only" for what the handler must get right and the limits no handler
+   fixes, and → "Delegate secret migration: no core mechanism, and why" for the
+   full history. See `contract-patterns.md` for the contract-side
    mechanics. For the procedure of swapping an existing hand-rolled sweep over
    to the crate, see the `freenet-migrate-adoption` skill.
 
@@ -435,7 +436,9 @@ failure a green test suite let through.
   the optional in-state `OptionalUpgrade` straggler pointer, and the preconditions.
 - `references/delegate-patterns.md` — delegate migration mechanics: the backward
   probe that re-runs the old delegate's WASM via `DelegateRequest::ApplicationMessages`
-  (there is **no `ExportSecrets` handler**), `legacy_delegates.toml`, the fragility
+  (there is **no `ExportSecrets` request in the stdlib wire protocol**, so the
+  predecessor answers with whatever handler it shipped with — see "A delegate
+  migration is forward-only" there), `legacy_delegates.toml`, the fragility
   when an stdlib/ABI bump strands old WASM, and the double-hashing bug.
 - `references/build-system.md` — byte-reproducibility (commit `Cargo.lock`, pin the
   toolchain, build `--locked`; and the `wasm-opt`/`dx`/path-embedding and

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -189,6 +189,69 @@ first-class upgrade path, not a loophole:
 
 Everything below applies to the WASM-change case.
 
+### A parameter-struct change is a migration too, and the lineage cannot express it
+
+The key is `BLAKE3(code_hash ‖ params)`, so **editing a contract's parameter
+struct re-keys every instance exactly as surely as editing the WASM does** —
+even when the WASM is byte-identical. That half of the formula is easy to forget
+because a parameter struct looks like an ordinary type.
+
+The trap is that `freenet-migrate` cannot notice.
+`ContractLineageEntry { generation, code_hash, note }` records **no parameter
+bytes**, and `contract::predecessor_ids(params, lineage)` maps *one* `params`
+— the current build's — over every entry. So after a parameter edit the probe
+walks a list of addresses that never existed, takes `NotFound` at each, and
+reports a clean "nothing to migrate". **Green tests, green CI, no runtime
+symptom, and every instance ever published is orphaned.** Harvest came within
+one commit of shipping that: removing two fields took `StoreParameters` from 109
+CBOR bytes to 56, which would have silently written off five generations of a
+seller's entire store.
+
+The remedy is to freeze a **generation boundary** and derive each predecessor
+under the encoding it was actually published with:
+
+```rust
+/// Generations at or below this were published under the OLD parameter shape.
+/// A fixed historical fact, not a thing to bump on the next re-key.
+pub const LAST_LEGACY_STORE_PARAM_GENERATION: u32 = 5;
+
+// A frozen copy of the old struct, written out rather than derived from the
+// live type -- deriving it from a type still being edited is how it goes
+// quietly wrong a second time.
+#[derive(serde::Serialize)]
+struct LegacyStoreParameters { /* ...the fields as they were, with the values
+                                  the publishing code actually supplied... */ }
+
+let params = if entry.generation <= LAST_LEGACY_STORE_PARAM_GENERATION {
+    &legacy
+} else {
+    &current
+};
+contract_id_from_code_hash(&entry.code_hash, params)
+```
+
+Harvest's `ui/src/migrate.rs` (`store_candidate_ids`,
+`legacy_store_params_cbor`) and `legacy/README.md` are the worked shape,
+including a test that pins the boundary.
+
+**This is a contract-side hazard specifically.** The delegate registry does not
+have it: `DelegateLineageEntry` stores the full `delegate_key` per row and the
+walk uses it verbatim, never re-deriving it (`delegate_migrate.rs:1547`), and
+the registry row carries an optional `params_hex` that the build-time
+cross-check honours. So a delegate parameter change is recorded correctly by
+construction; a contract parameter change is not recorded at all.
+
+Practical rules:
+
+- **Treat a parameter-struct edit as a re-key event** and put it through the same
+  procedure as a WASM change: record the outgoing generation before rebuilding.
+- **Prefer moving the field elsewhere.** Parameters are the address; state is
+  not. Harvest's two fields moved onto `Order` (state) rather than staying in
+  parameters, which is the change that caused this — but a field that lives in
+  state can be edited freely forever after.
+- **Say where the boundary falls in the registry file itself**, next to the rows
+  it splits, so the next person appending a row sees it.
+
 Therefore **the entire risk surface of an upgrade is the migration.** Don't aim
 for "risk-free upgrades" (impossible); aim for migrations that are *idempotent,
 resumable, non-destructive, regression-gated, and observable*. The five
@@ -234,9 +297,9 @@ properties below are the whole game.
 
    ```rust
    // On migration start (before the first per-entity write):
-   set_flag("migration_in_progress");      // browser localStorage, NOT the
-                                           // delegate -- see below; namespaced
-                                           // per source-version set
+   set_flag("migration_in_progress");      // in the DELEGATE's secret store --
+                                           // see below; namespaced per
+                                           // source-version set
    // ... write each entity via CAS ...
    // ONLY after every entity is written:
    clear_flag("migration_in_progress");
@@ -258,22 +321,67 @@ properties below are the whole game.
    populated: that is the empty-destination gate in disguise, and any earlier
    write then makes the migration permanently unreachable.
 
-   **Never keep a *contract* migration marker in the delegate.** The delegate is
-   the obvious home — it is already your durable client store, holding keys and
-   registries — and it is the wrong one, because a marker there is lost when the
-   **delegate** re-keys. That silently resets every contract marker at exactly the
-   moment the contracts re-keyed too, so the two failures arrive together and the
-   second one is invisible. Use browser `localStorage`, whose origin derives from
-   the web-container contract id and does not move when a data contract or a
-   delegate is rebuilt. Key it by `(artifact, instance, current_code_hash)` and
-   **hex-encode both ids**: raw bytes in a storage key alias under any lossy UTF-8
-   conversion, which is how two distinct 32-byte ids collapse onto one marker slot
-   and one of them gets sealed having never been migrated (River hit exactly that).
-   Make unreadable storage report **"not migrated"** — a private window, disabled
-   storage, or an embedding that denies access then costs one extra walk per page
-   load, which is wasteful and safe; reading it as "already done" skips the
-   migration entirely. Harvest's `ui/src/migrate.rs` (`marker_key` /
-   `migration_done`) is the worked shape.
+   **A published Freenet webapp has no browser storage, so the marker belongs in
+   the delegate's secret store.** The gateway serves a webapp in an iframe whose
+   `sandbox` attribute omits `allow-same-origin`
+   (`freenet-core:crates/core/src/server/path_handlers/assets/shell.html`), so the
+   app frame has an opaque origin and `window.localStorage` throws. A marker kept
+   there works under `dx serve` and is a silent no-op the moment it is published.
+   It is silent because it fails in the *safe* direction — unreadable reads as
+   "not migrated", so the walk repeats forever instead of being skipped — which
+   is exactly why nothing reports it. Harvest shipped that and found it only by
+   re-reading the sandbox attribute. (The *shell* is same-origin with the node and
+   does have storage, but that is the node's origin, shared by every app on it,
+   and your app frame cannot reach it — `path_handlers.rs:1672-1676`.)
+
+   The delegate's KV store is therefore the only durable client-side store you
+   have. Keeping a *contract* marker there costs one extra probe when the
+   **delegate** re-keys, and that is not the defect it looks like: the fold only
+   ever adds, and a delegate re-key is the moment your secrets moved too, so
+   re-probing then is the honest answer.
+
+   **The question that actually varies is whether the marker travels with a
+   delegate export.** The store must outlive every artifact whose migration the
+   marker records, *and* the marker must not survive into a context where its
+   claim has stopped being true. Those two pull in opposite directions, and which
+   one wins depends on what the marker names:
+
+   | The marker names… | Carried forward on export? | Why |
+   |---|---|---|
+   | a predecessor **delegate** (River) | **No** — keep it outside the exported prefix | Copying it forward asserts the successor already imported that predecessor. It has not — the marker would forge migration state. |
+   | a **contract** generation (Harvest) | **Yes** — put it inside the exported prefix | "Store contract X's predecessors were folded into it" is a fact about contracts. A delegate re-key does not change it, so carrying it is accurate and saves the re-probe above. |
+   | anything a late arrival could still invalidate (ghostkeys) | Not durable at all — page-lifetime only | Sealing a predecessor durably strands data that arrives after the seal. |
+
+   River and Harvest made opposite choices here and both are right; copy the
+   reasoning, never the choice. The crate's own `PRED_DONE_MARKER_KEY_PREFIX`
+   markers are not a fourth option: they seal *delegate* predecessors, live in
+   the successor's store under a `\0`-prefixed reserved namespace, and the driver
+   filters them out of exports. Contract markers are yours to place.
+
+   **The client must not supply a raw storage key.** Take a marker *id* and
+   prepend the namespace inside the delegate (`harvest:migrate:` ++ id). The same
+   secret store holds private keys, so a request that accepted a raw key would let
+   a migration note overwrite `harvest:rsa_sk:*` — a general hazard for any
+   delegate whose secret namespace is shared. Harvest pins it with a test that
+   sends the marker id `"harvest:rsa_sk:fp1"` and asserts the private key survives
+   (`delegates/harvest-delegate/src/markers.rs`).
+
+   **Key it by `(artifact, instance, current_code_hash)`, and require the id to be
+   ASCII at the delegate boundary.** Raw bytes in a storage key alias under any
+   lossy UTF-8 conversion: River's chat delegate builds its key with
+   `String::from_utf8_lossy` (`delegates/chat-delegate/src/utils.rs:9`), which maps
+   every invalid byte to U+FFFD, so two distinct 32-byte ids collapse onto one
+   marker slot and one gets sealed having never been migrated. Enforcing ASCII in
+   the delegate makes that a property of the store rather than a habit of today's
+   caller.
+
+   **An unreadable store, a refused write and a malformed id all report "not
+   migrated."** The probe then repeats, which is wasteful and safe; reading any of
+   them as "already done" skips the migration entirely. Harvest's
+   `ui/src/migrate.rs` (`probe_gate`, a pure function over a three-valued
+   `MarkerLookup` so silence is distinguishable from a definite absence at the
+   type level) and `delegates/harvest-delegate/src/markers.rs` are the worked
+   shape.
 
 3. **Non-destructive.** Never delete the source until the destination is
    confirmed complete. Keep the old blob/keys as a rollback fallback so an old or
@@ -460,6 +568,12 @@ failure a green test suite let through.
 - The `freenet-migrate-adoption` skill: the procedure for swapping an app's
   existing hand-rolled sweep over to the crate (call-site swap, dual-running,
   the parity test, what rollback cannot undo).
+- **Harvest citations point at a repository that is not public yet.** Several
+  rules here name `harvest-bitcoin` paths (`ui/src/migrate.rs`,
+  `delegates/harvest-delegate/src/markers.rs`, `legacy/README.md`) because that
+  is where they were found and pinned. The reasoning and the code sketches are
+  reproduced inline so nothing here depends on reading it; treat the paths as
+  provenance rather than a link to follow.
 - River as worked reference: freenet/river#345 (per-entity CAS keys), #352
   (resumable/interrupted-migration recovery), #253 (regression-gated legacy probe),
   #204 (old delegate WASM unrunnable after an stdlib bump), #393 (gitignored

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -241,15 +241,36 @@ Harvest's `ui/src/migrate.rs` (`store_candidate_ids`,
 `legacy_store_params_cbor`) and `legacy/README.md` are the worked shape,
 including a test that pins the boundary.
 
-**This is a contract-side hazard specifically.** The delegate registry does not
-have it: `DelegateLineageEntry` stores the full `delegate_key` per row and the
+**A generation boundary only works while each historical encoding maps onto a
+distinct code hash.** If the *same* WASM was ever published under two parameter
+shapes, the registry cannot even hold both rows —
+`freenet-migrate-build`'s `validate()` rejects a duplicate contract code hash
+(`BuildError::DuplicateCodeHash`) — and the branch above picks one encoding per
+row regardless, so one historical address is never probed. The general answer is
+to keep the historical `(code_hash, parameter_bytes)` **pairs** and derive a
+candidate id from each, rather than a boundary over a code-hash-only lineage.
+The crate supports it: `NewestFirst::assume_ordered` takes a candidate list the
+app derived itself, which `ProbeDriver::new` accepts in place of
+`NewestFirst::from_lineage`. (Harvest wraps that as its own
+`ProbeSession::start_with_candidates`; the crate has no such constructor.) A
+boundary constant is the simple case of deriving your own candidates, not a
+substitute for it.
+
+**The *registry-format* half of this is contract-side specifically.** The
+delegate registry can say what the contract registry cannot: `DelegateLineageEntry` stores the full `delegate_key` per row and the
 walk uses it verbatim, never re-deriving it (`delegate_migrate.rs:1547`), and
 the registry row carries an optional `params_hex` that the build-time
-cross-check honours — and if you change a delegate's parameters and forget to
-record them, `Registry::validate()` re-derives `blake3(code_hash ‖ params)`,
-finds a mismatch, and **fails the build**. That is the contrast worth holding
-on to: a delegate parameter change is either recorded or loud, while a contract
-parameter change is neither.
+cross-check honours. So the delegate registry *format* can express a parameter
+change, where the contract format cannot express one at all.
+
+**Noticing that you need a row is silent on both sides, though**, and this is
+the part to guard yourself. A parameters-only re-key leaves the WASM
+byte-identical, so a pre-publish check that compares code hashes reports
+"unchanged" and you never append a row — and `Registry::validate()` only
+cross-checks the rows that are *present*, so it cannot object to the row you
+did not write. Make your publish guard compare the **derived address**
+— `blake3(code_hash ‖ params)`, the thing that actually moved — rather than the
+code hash alone, or a parameters-only re-key ships with green CI on both sides.
 
 Practical rules:
 

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -187,11 +187,18 @@ first-class upgrade path, not a loophole:
 - **This whole document is about the other case** — your data contracts and
   delegates, where the WASM itself changes and state has to be carried forward.
 
-Everything below applies to the WASM-change case.
+Everything below applies to the case where the artifact's **address moves**:
+a WASM change, or the parameter change covered just below.
+
+Therefore **the entire risk surface of an upgrade is the migration.** Don't aim
+for "risk-free upgrades" (impossible); aim for migrations that are *idempotent,
+resumable, non-destructive, regression-gated, and observable*. The five
+properties below are the whole game.
 
 ### A parameter-struct change is a migration too, and the lineage cannot express it
 
-The key is `BLAKE3(code_hash ‖ params)`, so **editing a contract's parameter
+The formula at the top of this section has two halves, and only one of them is
+about WASM. `BLAKE3(code_hash || params)` means **editing a contract's parameter
 struct re-keys every instance exactly as surely as editing the WASM does** —
 even when the WASM is byte-identical. That half of the formula is easy to forget
 because a parameter struct looks like an ordinary type.
@@ -238,8 +245,11 @@ including a test that pins the boundary.
 have it: `DelegateLineageEntry` stores the full `delegate_key` per row and the
 walk uses it verbatim, never re-deriving it (`delegate_migrate.rs:1547`), and
 the registry row carries an optional `params_hex` that the build-time
-cross-check honours. So a delegate parameter change is recorded correctly by
-construction; a contract parameter change is not recorded at all.
+cross-check honours — and if you change a delegate's parameters and forget to
+record them, `Registry::validate()` re-derives `blake3(code_hash ‖ params)`,
+finds a mismatch, and **fails the build**. That is the contrast worth holding
+on to: a delegate parameter change is either recorded or loud, while a contract
+parameter change is neither.
 
 Practical rules:
 
@@ -247,15 +257,11 @@ Practical rules:
   procedure as a WASM change: record the outgoing generation before rebuilding.
 - **Prefer moving the field elsewhere.** Parameters are the address; state is
   not. Harvest's two fields moved onto `Order` (state) rather than staying in
-  parameters, which is the change that caused this — but a field that lives in
-  state can be edited freely forever after.
+  parameters, which is the change that caused this. A state field can then be
+  *extended* without re-keying anything — subject to architecture invariant 2
+  below, which still forbids removing, renaming or repurposing one.
 - **Say where the boundary falls in the registry file itself**, next to the rows
   it splits, so the next person appending a row sees it.
-
-Therefore **the entire risk surface of an upgrade is the migration.** Don't aim
-for "risk-free upgrades" (impossible); aim for migrations that are *idempotent,
-resumable, non-destructive, regression-gated, and observable*. The five
-properties below are the whole game.
 
 ## Architecture invariants (decide these before v1 — you cannot bolt them on)
 
@@ -334,29 +340,58 @@ properties below are the whole game.
    does have storage, but that is the node's origin, shared by every app on it,
    and your app frame cannot reach it — `path_handlers.rs:1672-1676`.)
 
-   The delegate's KV store is therefore the only durable client-side store you
-   have. Keeping a *contract* marker there costs one extra probe when the
-   **delegate** re-keys, and that is not the defect it looks like: the fold only
-   ever adds, and a delegate re-key is the moment your secrets moved too, so
-   re-probing then is the honest answer.
+   For a **browser** app the delegate's KV store is therefore the only durable
+   client-local store left. (A non-browser client has its own filesystem and
+   should use it — the freenet-bitcoin bridge keeps its markers in SQLite,
+   `bridge/src/store.rs:145`. A per-user contract keyed on the user's own
+   verifying key is also durable and survives a delegate re-key, at the cost of a
+   network round trip on every page load.)
 
-   **The question that actually varies is whether the marker travels with a
-   delegate export.** The store must outlive every artifact whose migration the
-   marker records, *and* the marker must not survive into a context where its
-   claim has stopped being true. Those two pull in opposite directions, and which
-   one wins depends on what the marker names:
+   Keeping a *contract* marker in the delegate costs one extra probe when the
+   **delegate** re-keys. That is not the defect it looks like **provided your fold
+   only ever adds** — check that it does, because a fold that can overwrite makes
+   the re-probe a regression rather than waste — and a delegate re-key is the
+   moment your secrets moved too, so re-probing then is the honest answer.
 
-   | The marker names… | Carried forward on export? | Why |
+   **Before making it durable at all, ask whether the predecessor store is
+   genuinely frozen after the re-key.** A durable marker is what makes a wrong
+   "nothing there" verdict permanent, so it is only safe when nothing can write
+   to a predecessor after you have declared it done. River's legacy delegates are
+   frozen — only the current delegate is ever written — so it seals. ghostkeys
+   **bans** durable markers for the opposite reason: a contrast test showed one
+   there resurrects a data-loss scenario verbatim. Decide per app, write down
+   which way and why, and never port one app's answer to another.
+
+   **If you do make it durable, the next question is whether it must be kept out
+   of a delegate export.** The store has to outlive every artifact whose
+   migration the marker records, *and* the marker must not survive into a context
+   where its claim has stopped being true. Those pull in opposite directions, and
+   which wins depends on what the marker names:
+
+   | The marker names… | Keep it out of the export? | Why |
    |---|---|---|
-   | a predecessor **delegate** (River) | **No** — keep it outside the exported prefix | Copying it forward asserts the successor already imported that predecessor. It has not — the marker would forge migration state. |
-   | a **contract** generation (Harvest) | **Yes** — put it inside the exported prefix | "Store contract X's predecessors were folded into it" is a fact about contracts. A delegate re-key does not change it, so carrying it is accurate and saves the re-probe above. |
-   | anything a late arrival could still invalidate (ghostkeys) | Not durable at all — page-lifetime only | Sealing a predecessor durably strands data that arrives after the seal. |
+   | a predecessor **delegate** (River) | **Yes** | When the current delegate later becomes a predecessor itself, its store holds these keys; copying them forward asserts the successor already imported that predecessor. It has not — the marker would forge migration state. |
+   | a **contract** generation (Harvest) | **No** — put it inside the exported prefix on purpose | "Store contract X's predecessors were folded into it" is a fact about contracts. A delegate re-key does not change it, so carrying it forward is accurate and saves the re-probe above. |
 
    River and Harvest made opposite choices here and both are right; copy the
-   reasoning, never the choice. The crate's own `PRED_DONE_MARKER_KEY_PREFIX`
-   markers are not a fourth option: they seal *delegate* predecessors, live in
-   the successor's store under a `\0`-prefixed reserved namespace, and the driver
-   filters them out of exports. Contract markers are yours to place.
+   reasoning, never the choice.
+
+   **Excluding a marker is an explicit predicate, not just a placement.** River
+   keeps its markers in the *ordinary* key space and filters them by prefix on
+   **both** sides — the fetch path (`candidate_keys`) and the import path
+   (`classify_recovered`), via `is_migration_marker_key` — precisely because a
+   predecessor read by key enumeration has no prefix boundary to hide behind.
+   Placing the marker outside an `ExportScope::Prefix` is a cheap extra guard when
+   your export is prefix-scoped; it is not sufficient on its own. The crate's own
+   `PRED_DONE_MARKER_KEY_PREFIX` markers are not a third option here: they seal
+   *delegate* predecessors, live under a `\0`-prefixed reserved namespace, and
+   the driver strips them from exports — but it strips only its own namespace, so
+   app-chosen markers stay the app's problem.
+
+   Markers carried inside an export also **consume the export's enumeration
+   budget**: `export_scoped` enumerates the whole scope regardless of prefix and
+   refuses at `HOST_ENUMERATION_CAP` (4096). Keep the marker key space bounded by
+   `(artifact, instance, code_hash)` rather than letting it grow per attempt.
 
    **The client must not supply a raw storage key.** Take a marker *id* and
    prepend the namespace inside the delegate (`harvest:migrate:` ++ id). The same
@@ -366,9 +401,9 @@ properties below are the whole game.
    sends the marker id `"harvest:rsa_sk:fp1"` and asserts the private key survives
    (`delegates/harvest-delegate/src/markers.rs`).
 
-   **Key it by `(artifact, instance, current_code_hash)`, and require the id to be
-   ASCII at the delegate boundary.** Raw bytes in a storage key alias under any
-   lossy UTF-8 conversion: River's chat delegate builds its key with
+   **Key it by `(artifact, instance, current_code_hash)`, mint the ids as hex, and
+   require ASCII at the delegate boundary.** Raw bytes in a storage key alias under
+   any lossy UTF-8 conversion: River's chat delegate builds its key with
    `String::from_utf8_lossy` (`delegates/chat-delegate/src/utils.rs:9`), which maps
    every invalid byte to U+FFFD, so two distinct 32-byte ids collapse onto one
    marker slot and one gets sealed having never been migrated. Enforcing ASCII in

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -229,12 +229,22 @@ pub const LAST_LEGACY_STORE_PARAM_GENERATION: u32 = 5;
 struct LegacyStoreParameters { /* ...the fields as they were, with the values
                                   the publishing code actually supplied... */ }
 
-let params = if entry.generation <= LAST_LEGACY_STORE_PARAM_GENERATION {
-    &legacy
-} else {
-    &current
-};
-contract_id_from_code_hash(&entry.code_hash, params)
+let mut by_generation: Vec<(u32, ContractInstanceId)> = lineage
+    .iter()
+    .map(|e| {
+        let params = if e.generation <= LAST_LEGACY_STORE_PARAM_GENERATION {
+            &legacy
+        } else {
+            &current
+        };
+        (e.generation, contract_id_from_code_hash(&e.code_hash, params))
+    })
+    .collect();
+// Newest-first, by the registry's DECLARED generation and never by slice
+// order. `NewestFirst::from_lineage` does this for you; a hand-derived list
+// handed to `assume_ordered` must do it itself, or a generation appended out
+// of order silently loses the anti-rollback guarantee.
+by_generation.sort_by_key(|(generation, _)| core::cmp::Reverse(*generation));
 ```
 
 Harvest's `ui/src/migrate.rs` (`store_candidate_ids`,


### PR DESCRIPTION
Field corrections to the migration material, from actually adopting `freenet-migrate` in a live app (Harvest). These are not review speculation — each is something the skill as written would have led an engineer into. Every claim was checked against `freenet-migrate` 0.3.0–0.6.0, `freenet-migrate-build` 0.2.0 and `freenet-stdlib` 0.6.1/0.8.2–0.8.5 in the cargo registry, plus `freenet-core@main` and `river@main`.

**Version 1.35.0** in `.claude-plugin/marketplace.json`, with CHANGELOG entries for both 1.34.0 and 1.35.0.

---

## The headline correction: where a migration marker goes

1.34.0 (the first half of this PR) said to keep a contract migration marker in browser `localStorage`. **That was wrong, and it is withdrawn.** A published Freenet webapp runs in an iframe whose `sandbox` omits `allow-same-origin` (`freenet-core:.../assets/shell.html:11`), so the app frame has an opaque origin and `localStorage` throws. A marker kept there works under `dx serve` and is a silent no-op the moment it is published — silent because it fails in the *safe* direction: unreadable reads as "not migrated", so the walk repeats forever rather than being skipped. Harvest shipped exactly that.

The delegate's secret store is the only durable client-local store a browser app has, so 1.34.0's "never keep a contract marker in the delegate" is reversed outright.

**The question that actually varies is whether the marker travels with a delegate export, and it turns on what the marker names:**

- A marker naming a predecessor **delegate** must not travel — carrying it into a successor asserts an import that never happened. River's case.
- A marker naming a **contract** generation should travel — a delegate re-key does not change a fact about contracts. Harvest's case, where markers sit inside the exported prefix deliberately.

Two apps, opposite choices, both correct. Also: excluding a marker is an explicit predicate on both the fetch and import path, not merely a placement (River's markers live in the ordinary key space); a delegate marker request must take an *id* and prepend its own namespace, because the same secret store holds private keys; and a definitive answer is necessary but **not sufficient** to seal — the prior question is whether the predecessor store is genuinely frozen.

## New: a parameter-struct change is itself a migration

A contract's address is `BLAKE3(code_hash ‖ parameter_bytes)`, but `ContractLineageEntry` is `{generation, code_hash, note}` and `predecessor_ids(params, lineage)` maps *one* set of parameter bytes over every row. So **editing a parameter struct orphans every instance ever published**, and the probe reports a clean "nothing to migrate" with green tests, green CI and no runtime symptom. Harvest came within one commit of that: removing two fields took `StoreParameters` from 109 CBOR bytes to 56.

Remedy, with its two limits stated: a frozen generation boundary works only while each historical encoding maps onto a distinct code hash (`freenet-migrate-build` rejects duplicate contract code hashes), and *noticing* you need a row is silent on the delegate side too — a parameters-only re-key leaves the WASM byte-identical, so a code-hash-comparing publish guard says "unchanged".

## New: `Ok(vec![])` is a positive claim and seals permanently

An empty-success answer from `PredecessorSecretsIo::fetch_secrets` is indistinguishable from "nothing was there" and writes a `Done { had_data: false }` marker never revisited. The crate's own words: *"the cost of a wrong `Err` is one retry, the cost of a wrong `Ok(vec![])` is the user's data"* (`delegate_migrate.rs:434-436`).

## The 1.34.0 corrections that stand

1. **A delegate migration is forward-only.** The successor *asks*; only a predecessor whose already-deployed WASM can answer will. Every release shipped without an export handler adds one permanently unrecoverable generation — which makes "we have no migration to do yet" the argument for adopting *sooner*.
2. **"There is no `ExportSecrets` handler" was stale** — true of the stdlib wire protocol, false of `freenet-migrate`, which has shipped `handle_export_request` since **0.3.0**.
3. **Registry placement** gets the invariant that actually forbids the wrong choice: *a one-line registry edit must not change the contract WASM bytes*. Two shapes satisfy it — outside the contract build graph (Harvest), or inside it behind `#[cfg(feature = "migration")]` (River). Not an absolute against codegen from an in-graph crate; River does exactly that, correctly.
4. **`ProbeDriver`, not `migrate_contract`, in shared-handler environments.**
5. **Guards that provably cannot fail** — a wildcard arm over a `#[non_exhaustive]` enum wants a source-scrape pin *alongside* the behavioural test.
6. **`ContractInstanceId::from_bytes` is deprecated in 0.8.5** in favour of `from_base58`, which parses base58 *text* — so code passing it a raw 32-byte id was already wrong and wants `ContractInstanceId::new`.

## Also fixed on the way

`contract-patterns.md` listed `SeedLocal` under "may seal", contradicting a paragraph twelve lines above it and the `freenet-app-migration` skill that owns the rule. The crate settles it: *"`Outcome::SeedLocal` deliberately does not claim to be sealable"* (`driver.rs:160`). Introduced in 1.33.0, removed here.

Its registry description also claimed contract rows carry "the params bytes used to derive the key". They do not, which is the premise of the new parameter rule.

## Review

Blocking finding from the independent pass resolved (see [the reply](https://github.com/freenet/freenet-agent-skills/pull/73#issuecomment-5544066221)). Three further passes ran on the corrected content — two blind Claude lenses and `codex review` — and each found real errors, all fixed: a fabricated trait name (`SecretsMigrationIo`; it is `PredecessorSecretsIo`), a table prescribing a mechanism River does not use, an over-claim that a delegate parameter change "fails the build", a `start_with_candidates` cited as crate API when it is Harvest's wrapper, a code sketch that dropped the newest-first sort `assume_ordered` requires, and a TypeScript aside that told readers they were exempt from the `Absent`/`Unknown` distinction when `FreenetWsApi` correlates FIFO and rejects on `NotFound` exactly as it rejects on timeout.

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop

[AI-assisted - Claude]
