### PR TITLE
docs(dapp-builder): pointer I/O seam, author-side publishing, and build reproducibility (v1.36.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI coding agent skills for Freenet development",
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.36.0 (2026-09-04)
+
+Field findings from a night of building and deploying a Freenet app. Two are
+corrections to text that was already here.
+
+- **The fallback rule, corrected.** `building-on-other-apps.md` opened by saying
+  that for an app with no pointer, a resolve returns `NeverPublished` **or**
+  `Unavailable` "and the baked-in fallback is legitimately what you use". That
+  licensed the fallback on `Unavailable`, contradicting the same file's own
+  outcome table, its "true for `NeverPublished` and nothing else" line, and
+  `PointerOutcome::may_use_baked_in_fallback`. Treating "could not reach it" as
+  "it does not exist" is a free downgrade for anyone who can drop a GET, and the
+  wrong sentence was in the opening call-out, aimed at first-run readers.
+- **`--remap-path-prefix` on your own source is not enough.** Release binaries
+  embed panic locations as `file:line`, and cargo passes absolute paths for
+  dependencies, so the cargo registry root lands in the WASM. Measured in a real
+  contract: twelve registry roots, 21 occurrences. Since the address is
+  `BLAKE3(BLAKE3(wasm) ‖ params)`, every contract built was bound to its build
+  machine, and a runner and a dev box produced different contracts from one
+  commit. `CARGO_HOME` and `RUSTUP_HOME` must be remapped too, the replacement
+  names become part of the contract's identity, and the check must be
+  fail-closed — refuse the build if any build-machine path survives.
+- **A stale `target/` silently changes contract identity.** `cargo clean -p` on
+  workspace crates is insufficient: dependency artifacts are reused and under fat
+  LTO yield a different module. Build into a throwaway target dir for anything
+  whose hash you record. The CI `wasm-staleness` sample was updated to go through
+  the canonical script from a `mktemp -d` rather than a bare `cargo build`, which
+  under the new doctrine would have failed on the runner's own paths.
+- **The pointer's I/O seam.** `PointerFetch` is three-way (`State` / `Absent` /
+  `Unreachable`) for the same reason `ProbeAnswer` is: a transport wired as a
+  two-way `Option` can never reach `NeverPublished` and so silently deletes its
+  own fallback. And a pointer GET must not request the contract code — 100 bytes
+  of answer against ~130 KB of WASM — which is why `PointerIo` exists separately
+  from `ProbeIo`, and what `ConservativeProbeIo` costs.
+- **Author-side pointer publishing.** A publish at an already-used version is a
+  silent no-op *success*, so re-read the pointer afterwards; the network will
+  never tell you a release was ignored. Losing the version counter's store
+  freezes the pointer at a generation you no longer write to, and recovering the
+  version from the network is safe only from a record that verifies under your
+  own key — an unverified read-back gets **you** to sign just below the
+  unsupersedable `u32::MAX - 1` ceiling.
+- **`SuccessorPointer` named as the fourth pointer-like thing**, with its own
+  signing domain (`freenet-migrate/successor-v1`), alongside the pointer
+  contract, `OptionalUpgrade` and `FacadePointer`. Importing the wrong one
+  compiles.
+
 ## 1.35.0 (2026-09-04)
 
 Resolves the blocking review finding on 1.34.0's marker rule, and adds two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,32 @@ corrections to text that was already here.
   contract, `OptionalUpgrade` and `FacadePointer`. Importing the wrong one
   compiles.
 
+Review of the above turned up four more corrections to existing text, all of the
+"doctrine changed here, the worked example still teaches the old thing" kind:
+
+- **`-Ctrim-paths` does not exist.** The byte-reproducibility section offered it
+  as an equivalent alternative to `--remap-path-prefix`. `rustc -Ctrim-paths=all`
+  is an "unknown codegen option", and Cargo's `trim-paths = "all"` profile
+  setting is still unstable on Rust 1.96.0, which is what the exemplar project
+  pins. `--remap-path-prefix` is the option that works today.
+- **The canonical `Makefile.toml` example built the contract and the delegate in
+  two separate bare `cargo build -p` invocations** — simultaneously the
+  feature-unification footgun the same file warns about three sections later, and
+  an unremapped build. It now calls one script that co-builds both.
+- **Two more places recorded a hash out of a long-lived shared `target/`** (the
+  plain-Makefile delegate recipe and the `ui-patterns.md` constant injection),
+  and `facade-pattern.md`'s list of reasons a byte-equality check fails did not
+  include either new cause. All three now cross-reference the rule.
+- **The withdrawal-floor exception was missing from the doctrine-owning skill.**
+  "Keep the key you last resolved" inverts under a withdrawal floor — following
+  it there resurrects code the author retired. `freenet-app-migration` declares
+  itself the winner in a disagreement, so the exception had to be in it.
+
+Also corrected in the new text itself: a miscounted number of embedded registry
+roots, an overstated claim about wall-clock timestamps landing at `u32::MAX`, and
+an attribution of the throwaway target dir to the build script rather than to its
+callers.
+
 ## 1.35.0 (2026-09-04)
 
 Resolves the blocking review finding on 1.34.0's marker rule, and adds two

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -378,18 +378,20 @@ Set up the build system, CI, and deployment pipeline.
    browser console is clean catches CSP blocks, iframe-shell mistakes, and
    broken archives that no unit test reaches. See
    `references/production-smoke-testing.md`.
-6. **Check the gateway port and (optionally) tar reproducibility.** The
+6. **Check the gateway port, and make the build reproducible.** The
    gateway runs on `7509` — older docs and scripts still reference `50509`.
    For byte-reproducible webapp archives across build hosts, invoke `tar`
    with the GNU flags listed under "Tooling Preflight" in
    `references/build-system.md`.
 
-   **Contracts need more than reproducible tars.** Build them through one
-   canonical script that remaps `CARGO_HOME`, `RUSTUP_HOME` and the repo root,
-   refuses if any build-machine path survives into the WASM, and builds into a
-   throwaway target dir. Remapping only your own source path leaves the cargo
-   registry's absolute paths in the bytes, which binds every contract to the
-   machine that built it. See "Byte-reproducibility" in
+   **Contracts need more than reproducible tars, and this part is not
+   optional** — the WASM bytes *are* the contract's address. Build them through
+   one canonical script that remaps `CARGO_HOME`, `RUSTUP_HOME` **and** the repo
+   root, and that refuses the build if any build-machine path survives into the
+   WASM. Remapping only your own source path leaves the cargo registry's absolute
+   paths in the bytes, which binds every contract to the machine that built it.
+   Have the script take its target dir as an argument, so any build whose hash you
+   record or pin can go into a throwaway one. See "Byte-reproducibility" in
    `references/build-system.md`.
 
 7. **Publish the UI as a web container contract — its URL is permanent, and

--- a/skills/dapp-builder/SKILL.md
+++ b/skills/dapp-builder/SKILL.md
@@ -384,6 +384,14 @@ Set up the build system, CI, and deployment pipeline.
    with the GNU flags listed under "Tooling Preflight" in
    `references/build-system.md`.
 
+   **Contracts need more than reproducible tars.** Build them through one
+   canonical script that remaps `CARGO_HOME`, `RUSTUP_HOME` and the repo root,
+   refuses if any build-machine path survives into the WASM, and builds into a
+   throwaway target dir. Remapping only your own source path leaves the cargo
+   registry's absolute paths in the bytes, which binds every contract to the
+   machine that built it. See "Byte-reproducibility" in
+   `references/build-system.md`.
+
 7. **Publish the UI as a web container contract — its URL is permanent, and
    you upgrade in place.** Shipping a new release does **not** rotate the
    gateway URL: the UI is the container's *state*, while the contract key is

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -202,7 +202,11 @@ runs ahead. Prefer a committed monotonic counter file.
 - `rust-toolchain.toml` must be committed and mirrored in any CI
   workflow that rebuilds the contract — rustc version affects WASM
   bytes, and the byte-equality check will fail if CI's rustc differs
-  from the one that produced the committed snapshot.
+  from the one that produced the committed snapshot. Rustc is not the
+  only cause, and mirroring the toolchain alone will not fix a CI
+  mismatch: absolute build paths and a stale `target/` both move the
+  bytes too. See "Byte-reproducibility" below before concluding it is
+  the compiler.
 
 ## Byte-reproducibility: the lockfile is necessary but NOT sufficient
 
@@ -240,12 +244,55 @@ covered by the lockfile:
   re-keyed the contracts and the successor came up with zero claims. Either treat a
   contract crate's formatting as frozen between deliberate re-keys, or run `cargo
   fmt` and re-key on purpose, registering the outgoing hash first.
-- **Absolute build-path embedding.** rustc bakes absolute paths (e.g.
-  `/home/you/.cargo/registry/...`) into the WASM, so the *same* lock + toolchain
-  on a different machine or username still produces different bytes. Strip them
-  with `-Ctrim-paths` (`trim-paths = "all"` in the release profile) or
-  `--remap-path-prefix`, or build in a pinned container. (River verified this and
-  is adopting `trim-paths` on its next deliberate re-key — freenet/river#393.)
+- **Absolute build-path embedding — and remapping your own source path is not
+  enough.** Release binaries embed panic locations as `file:line`, and for
+  dependencies cargo passes **absolute** paths, so the registry root lands in the
+  bytes. Measured in a real contract: `/home/ian/.cargo/registry/.../blake3-1.8.7/`
+  plus eleven other registry roots, 21 occurrences in one WASM. Because the address
+  is `BLAKE3(BLAKE3(wasm) ‖ params)`, **every contract that project had built was
+  bound to the machine that built it** — a GitHub runner and the dev box produced
+  different contracts from one commit, so nobody could reproduce what was deployed.
+  A developer who remaps only the repo root will still ship a machine-specific
+  contract and see nothing wrong.
+
+  Remap all three varying roots — `CARGO_HOME`, `RUSTUP_HOME`, and the repo — or
+  use `-Ctrim-paths` (`trim-paths = "all"` in the release profile), which covers
+  dependency and sysroot paths too, or build in a pinned container. (River verified
+  this and is adopting `trim-paths` on its next deliberate re-key —
+  freenet/river#393.) The working example is
+  `freenet-bitcoin/scripts/build-contracts.sh`:
+
+  ```bash
+  CARGO_DIR="${CARGO_HOME:-$HOME/.cargo}"
+  RUSTUP_DIR="${RUSTUP_HOME:-$HOME/.rustup}"
+
+  export CARGO_BUILD_RUSTFLAGS="\
+  --remap-path-prefix=$CARGO_DIR=/cargo \
+  --remap-path-prefix=$RUSTUP_DIR=/rustup \
+  --remap-path-prefix=$REPO=/build"
+  ```
+
+  **The replacement names are now part of the contract's identity.** They are
+  arbitrary, but changing one re-keys every contract, so pick them once and treat
+  them as frozen. This is also why the flags belong in one canonical script and
+  nowhere else: a second invocation that sets them differently, or not at all,
+  produces a different contract while looking like the same command.
+
+- **A stale `target/` silently changes contract identity.** `cargo clean -p` on the
+  workspace crates is **not** sufficient: dependency artifacts are reused, and under
+  fat LTO they yield a different module and therefore a different contract. Measured
+  the same day — two fresh clones at different paths agreed with each other, and a
+  long-lived working tree agreed with neither. Anything whose hash you intend to
+  record or pin must be built into a throwaway target dir:
+
+  ```bash
+  D=$(mktemp -d); ./scripts/build-contracts.sh "$D"; rm -rf "$D"
+  ```
+
+  The nasty case is not a build that fails; it is a bundle built against a stale
+  `target/` that derives perfectly self-consistent addresses for a contract nobody
+  publishes to any more. That has happened. Cross-check the embedded bytes against
+  the migration registry, not only against themselves.
 
 **Build-command footgun — always use the canonical build script.** Building a
 contract crate **alone** (`cargo build -p my-contract`) can produce *different*
@@ -772,6 +819,42 @@ build script that "warns" on stderr and continues is silent rather than loud. An
 a `cargo:warning` is not a gate even on stdout, because nothing fails on it: when
 a build script finds a condition that must stop the build, `panic!`.
 
+### Verify no build-machine path survived, and fail closed
+
+A hash-equality check cannot catch a machine-specific path, because the committed
+artifact it compares against was produced on the same machine. It needs its own
+check, and that check must **refuse the build** rather than warn — the same
+argument as the `cargo:warning` one above, applied to the bytes. From
+`freenet-bitcoin/scripts/build-contracts.sh`:
+
+```bash
+for f in "$OUT"/my_contract.wasm; do
+  for probe in "$CARGO_DIR" "$RUSTUP_DIR" "$REPO" "${HOME:-/nonexistent}"; do
+    if grep -qaF -- "$probe" "$f"; then
+      echo "REFUSING: $(basename "$f") contains the build-machine path '$probe'." >&2
+      exit 1
+    fi
+  done
+  # A path belonging to some other user means a root nobody remapped.
+  if grep -qaE -- '/(home|Users)/[A-Za-z0-9._-]+/' "$f"; then
+    echo "REFUSING: $(basename "$f") contains a home-directory path." >&2
+    grep -aoE -- '/(home|Users)/[A-Za-z0-9._/-]{0,60}' "$f" | sort -u | head >&2
+    exit 1
+  fi
+done
+```
+
+Two things make this work. It is a **deny-list of roots known to vary**, not an
+allow-list of acceptable path shapes — an allow-list would have to enumerate every
+shape a path can take. And the second, generic `/home|/Users` probe catches a root
+nobody thought to remap: a vendored artifact, a build script writing its own path,
+a dependency baking one in. A varying root that is not on the list is the next
+instance of this bug.
+
+Put the check in the canonical build script, so it runs on the path `publish`
+actually takes, and not only in CI — see "Pre-Publish Checks" below on why a gate
+that lives only in CI is a gate the publish can walk around.
+
 ## Testing with Local Mode
 
 Freenet's **local mode** runs a standalone executor without network connectivity. Use this for testing contract and delegate logic during development.
@@ -955,11 +1038,21 @@ jobs:
       - run: cargo install b3sum
       - name: Verify committed WASMs match source
         run: |
-          cargo build --release --target wasm32-unknown-unknown -p my-delegate
+          # Go through the canonical script, never a bare `cargo build`: it sets
+          # the --remap-path-prefix flags and runs the fail-closed path check.
+          # A bare build here embeds the runner's paths and this job fails on a
+          # difference that is about the runner, not about the source.
+          D=$(mktemp -d)
+          ./scripts/build-contracts.sh "$D"
           COMMITTED=$(b3sum ui/public/contracts/my_delegate.wasm | cut -d' ' -f1)
-          BUILT=$(b3sum target/wasm32-unknown-unknown/release/my_delegate.wasm | cut -d' ' -f1)
+          BUILT=$(b3sum "$D/wasm32-unknown-unknown/release/my_delegate.wasm" | cut -d' ' -f1)
           [ "$COMMITTED" = "$BUILT" ] || { echo "::error::WASM stale"; exit 1; }
 ```
+
+Note this job deliberately does **not** restore the `target` cache the `test` job
+above uses. It builds into a fresh `mktemp -d`, because a hash recorded from a
+reused `target/` is not trustworthy (see "Byte-reproducibility"). Caching the
+registry is fine; caching `target` for a job whose entire output is a hash is not.
 
 ## Resilience Patterns
 

--- a/skills/dapp-builder/references/build-system.md
+++ b/skills/dapp-builder/references/build-system.md
@@ -248,7 +248,7 @@ covered by the lockfile:
   enough.** Release binaries embed panic locations as `file:line`, and for
   dependencies cargo passes **absolute** paths, so the registry root lands in the
   bytes. Measured in a real contract: `/home/ian/.cargo/registry/.../blake3-1.8.7/`
-  plus eleven other registry roots, 21 occurrences in one WASM. Because the address
+  and thirteen other crate roots, 21 occurrences in one WASM. Because the address
   is `BLAKE3(BLAKE3(wasm) ‖ params)`, **every contract that project had built was
   bound to the machine that built it** — a GitHub runner and the dev box produced
   different contracts from one commit, so nobody could reproduce what was deployed.
@@ -256,10 +256,14 @@ covered by the lockfile:
   contract and see nothing wrong.
 
   Remap all three varying roots — `CARGO_HOME`, `RUSTUP_HOME`, and the repo — or
-  use `-Ctrim-paths` (`trim-paths = "all"` in the release profile), which covers
-  dependency and sysroot paths too, or build in a pinned container. (River verified
-  this and is adopting `trim-paths` on its next deliberate re-key —
-  freenet/river#393.) The working example is
+  build in a pinned container. **`--remap-path-prefix` is the option that works
+  today.** Cargo's `trim-paths = "all"` profile setting covers dependency and
+  sysroot paths more thoroughly, but it is still unstable: on Rust 1.96.0 it fails
+  with *"the package requires the Cargo feature called `trim-paths`, but that
+  feature is not stabilized in this version of Cargo"*, and there is no
+  `-Ctrim-paths` codegen flag at all (`rustc -Ctrim-paths=all` → *"unknown codegen
+  option"*). Check stabilization before reaching for it; River intends to adopt it
+  on its next deliberate re-key (freenet/river#393). The working example is
   `freenet-bitcoin/scripts/build-contracts.sh`:
 
   ```bash
@@ -394,19 +398,21 @@ default_to_workspace = false
 # CONTRACT BUILD
 # ============================================
 
-[tasks.build-contract]
-description = "Build the contract to WASM"
-command = "cargo"
-args = [
-    "build",
-    "--release",
-    "--target", "wasm32-unknown-unknown",
-    "-p", "my-contract",
-]
+# One task builds BOTH wasm crates, through the one script that sets the
+# --remap-path-prefix flags and runs the fail-closed path check. Two separate
+# `cargo build -p` tasks would be two bugs at once: each crate would be built
+# without the sibling, changing the feature unification and therefore the key
+# (see "Build-command footgun"), and neither would be remapped, binding both
+# contracts to this machine (see "Byte-reproducibility").
+[tasks.build-contracts]
+description = "Build contract + delegate to WASM, reproducibly"
+script = '''
+./scripts/build-contracts.sh
+'''
 
 [tasks.copy-contract]
 description = "Copy contract WASM to UI public folder"
-dependencies = ["build-contract"]
+dependencies = ["build-contracts"]
 script = '''
 mkdir -p ui/public/contracts
 cp target/wasm32-unknown-unknown/release/my_contract.wasm ui/public/contracts/
@@ -416,19 +422,9 @@ cp target/wasm32-unknown-unknown/release/my_contract.wasm ui/public/contracts/
 # DELEGATE BUILD
 # ============================================
 
-[tasks.build-delegate]
-description = "Build the delegate to WASM"
-command = "cargo"
-args = [
-    "build",
-    "--release",
-    "--target", "wasm32-unknown-unknown",
-    "-p", "my-delegate",
-]
-
 [tasks.copy-delegate]
 description = "Copy delegate WASM to UI public folder"
-dependencies = ["build-delegate"]
+dependencies = ["build-contracts"]
 script = '''
 mkdir -p ui/public/contracts
 cp target/wasm32-unknown-unknown/release/my_delegate.wasm ui/public/contracts/
@@ -691,7 +687,11 @@ publish-delegate:
 	    node -e "const bs58=require('bs58'); \
 	        console.log(JSON.stringify(Array.from(bs58.default.decode('$$key'))))" \
 	        > $(WEB_DIR)/delegate_key_bytes.json
-	# 2. Compute code_hash from raw WASM (BLAKE3)
+	# 2. Compute code_hash from raw WASM (BLAKE3).
+	#    This value is baked into the UI, so it must come from a build you
+	#    trust: a reused CARGO_TARGET_DIR can change the bytes (see
+	#    "Byte-reproducibility"). Point CARGO_TARGET_DIR at a fresh dir for
+	#    any build whose hash you record.
 	code_hash_hex=$$(b3sum --no-names \
 	    $(CARGO_TARGET_DIR)/wasm32-unknown-unknown/release/my_delegate.wasm) && \
 	    node -e "console.log(JSON.stringify(Array.from( \
@@ -1024,6 +1024,8 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
       - name: Check WASM builds
+        # Compile check only — nothing here is hashed, committed or published.
+        # Bytes destined for publication come from scripts/build-contracts.sh.
         run: cargo build --release --target wasm32-unknown-unknown -p my-contract -p my-delegate
       - name: Check UI builds
         run: cargo check -p my-ui --target wasm32-unknown-unknown
@@ -1049,10 +1051,14 @@ jobs:
           [ "$COMMITTED" = "$BUILT" ] || { echo "::error::WASM stale"; exit 1; }
 ```
 
-Note this job deliberately does **not** restore the `target` cache the `test` job
+Note this job deliberately does **not** restore the `target` cache the `check` job
 above uses. It builds into a fresh `mktemp -d`, because a hash recorded from a
 reused `target/` is not trustworthy (see "Byte-reproducibility"). Caching the
 registry is fine; caching `target` for a job whose entire output is a hash is not.
+This is stricter than most projects currently manage — freenet-bitcoin's own CI
+still uses `Swatinem/rust-cache` and the default `target/` for its hash-reporting
+steps — so treat it as the bar to move towards, and be aware that a pinned-vector
+test running out of a cached tree is weaker evidence than it looks.
 
 ## Resilience Patterns
 

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -32,10 +32,13 @@ one does not solve yours.
 > same 32 raw bytes, and it is those 32 bytes the resolver wants.
 >
 > Everything else, including ghostkeys, has no record — so for those your
-> resolve returns `NeverPublished` (a real "not found"), and the baked-in
-> fallback is legitimately what you use. **`Unavailable` is not that case**: it
-> means your transport could not tell, and it never licenses the fallback, on an
-> unpublished app or any other. Retry instead. (An earlier version of this
+> resolve returns `NeverPublished` (a real "not found"), the one outcome that
+> *permits* a baked-in key. For these apps the **bundle fetch** at the end of this
+> file is still the better answer, and is what ghostkeys itself does; the
+> permission matters because it is what makes a fallback legitimate at all.
+> **`Unavailable` is not that case**: it means your transport could not tell, and
+> it never licenses the *baked-in* fallback, on an unpublished app or any other.
+> Retry instead. (An earlier version of this
 > paragraph named the two outcomes together, which contradicted both the outcome
 > table below and `may_use_baked_in_fallback`; treating "could not reach it" as
 > "it does not exist" is a free downgrade for anyone who can drop your GET.)
@@ -198,8 +201,11 @@ never a timeout, a send failure, or a malformed reply, all of which are
 means you can never reach `NeverPublished` and have silently deleted the only
 outcome that unlocks your fallback. This is the same mistake as `ProbeAnswer`'s
 on the backward side (freenet-migrate#19), in the same crate, for the same
-reason. An empty response body is `Unreachable` too, not `Absent`: those bytes
-came from a peer, and the contract rejects empty state as invalid.
+reason. An empty response body must never reach `Absent` either: those bytes came from a
+peer, and the contract rejects empty state as invalid. The crate enforces this
+itself — an empty `State(vec![])` is turned into `PointerOutcome::Unavailable`
+rather than `NeverPublished` — so the rule to keep is that only a real
+"not found" may ever be reported as `Absent`.
 
 **The GET must not request the contract code.** The 100-byte record is the whole
 answer; the pointer's own WASM is around 130 KB, and fetching it on every
@@ -395,9 +401,13 @@ your own re-keys, and it costs one signed 100-byte record per release.
 - **The author key is a long-lived identity.** Keep it offline; it is not a
   per-release key and there is deliberately no delegated signing.
 - **Gate `version` on a single committed monotonic counter**, the way a
-  web-container version counter works — never a wall-clock timestamp. A
-  timestamp lands near `u32::MAX`, and `MAX_POINTER_VERSION` is `u32::MAX - 1`
-  precisely because a record at the ceiling could never be superseded.
+  web-container version counter works — never a wall-clock timestamp. The
+  contract's own docs give burning the version space as the reason ("an author
+  deriving `version` from a timestamp would land there", i.e. at the reserved
+  `u32::MAX`); a Unix *seconds* timestamp is only about 42% of `u32::MAX` today,
+  so the immediate harm is less that you hit the ceiling than that you can never
+  go back down and have thrown away most of the range. Either way a counter is
+  the answer.
 - **Re-read the pointer after publishing and confirm the version and code hash
   are the ones you meant.** A publish at an already-used version is a silent
   no-op *success* — the contract deliberately does not error on a stale update,
@@ -410,7 +420,9 @@ your own re-keys, and it costs one signed 100-byte record per release.
   the opposite failure and is worse: nobody else can move your pointer, since
   only your key signs a record the contract accepts, so a peer that answers with
   a forged high version simply gets **you** to sign the next one just below the
-  unsupersedable ceiling. Monotonicity means you cannot walk it back down.
+  ceiling. `MAX_POINTER_VERSION` is `u32::MAX - 1` because `u32::MAX` itself is
+  reserved: a record there could never be superseded. Monotonicity means you
+  cannot walk a version back down.
 - **PUT the committed, published WASM artifact; never a local rebuild.** A local
   rebuild puts your pointer at an address nobody else derives: invisible to every
   consumer, and indistinguishable from success on your side.

--- a/skills/dapp-builder/references/building-on-other-apps.md
+++ b/skills/dapp-builder/references/building-on-other-apps.md
@@ -32,9 +32,14 @@ one does not solve yours.
 > same 32 raw bytes, and it is those 32 bytes the resolver wants.
 >
 > Everything else, including ghostkeys, has no record — so for those your
-> resolve returns `NeverPublished` (a real "not found") or `Unavailable` (your
-> transport could not tell), and the baked-in fallback is legitimately what you
-> use. Worth noticing that ghostkeys — the app whose re-keys caused the breakage
+> resolve returns `NeverPublished` (a real "not found"), and the baked-in
+> fallback is legitimately what you use. **`Unavailable` is not that case**: it
+> means your transport could not tell, and it never licenses the fallback, on an
+> unpublished app or any other. Retry instead. (An earlier version of this
+> paragraph named the two outcomes together, which contradicted both the outcome
+> table below and `may_use_baked_in_fallback`; treating "could not reach it" as
+> "it does not exist" is a free downgrade for anyone who can drop your GET.)
+> Worth noticing that ghostkeys — the app whose re-keys caused the breakage
 > this file exists to prevent — is still in that group, so the reader most likely
 > to reach for a pointer is the one it cannot yet help.
 >
@@ -85,7 +90,12 @@ which is what makes this work for a third party. The in-state `OptionalUpgrade`
 pointer in `contract-patterns.md` is a different thing: it is per-instance and
 only findable by a client that already holds a reference to *that* contract. The
 `FacadePointer` in `facade-pattern.md` is a third thing again: it moves an
-audience to a different contract, for the author's own users.
+audience to a different contract, for the author's own users. And
+`freenet_migrate::SuccessorPointer` is a fourth: an older, unrelated primitive
+in the same crate, signing under `freenet-migrate/successor-v1` where the
+pointer contract signs under `freenet-pointer/state-v1`, with a different
+message layout. A signature under one domain never verifies under the other, so
+they are not interchangeable and importing the wrong one compiles.
 
 Mechanics, wire format, and the operational requirements are in the contract's
 own README — do not restate them here, or the two copies drift:
@@ -175,6 +185,29 @@ leaves you pinned for the life of the session, and repeated resolving is the
 only thing that bounds how long an author's newer record can be suppressed from
 you. Subscribing to the pointer is a best-effort accelerant, not a substitute:
 subscriptions are dropped silently across reconnects.
+
+### The transport you hand it
+
+`resolve_app_pointer` drives a `PointerIo` you implement, and two properties of
+that implementation are load-bearing.
+
+**Its result type is three-way on purpose.** `PointerFetch` is `State` /
+`Absent` / `Unreachable`, and `Absent` means *you asked and were told no* —
+never a timeout, a send failure, or a malformed reply, all of which are
+`Unreachable`. Wire it as a two-way `Option` and you collapse those two, which
+means you can never reach `NeverPublished` and have silently deleted the only
+outcome that unlocks your fallback. This is the same mistake as `ProbeAnswer`'s
+on the backward side (freenet-migrate#19), in the same crate, for the same
+reason. An empty response body is `Unreachable` too, not `Absent`: those bytes
+came from a peer, and the contract rejects empty state as invalid.
+
+**The GET must not request the contract code.** The 100-byte record is the whole
+answer; the pointer's own WASM is around 130 KB, and fetching it on every
+resolve is pure waste. This is the one reason `PointerIo` exists as its own
+trait rather than reusing `ProbeIo`, whose GET *does* request the code because a
+backward probe needs it. `ConservativeProbeIo` adapts a `ProbeIo` you already
+have and is fine for reusing plumbing, but it inherits that cost — implement
+`PointerIo` directly for anything that resolves often.
 
 ### Four things people get wrong
 
@@ -362,7 +395,22 @@ your own re-keys, and it costs one signed 100-byte record per release.
 - **The author key is a long-lived identity.** Keep it offline; it is not a
   per-release key and there is deliberately no delegated signing.
 - **Gate `version` on a single committed monotonic counter**, the way a
-  web-container version counter works — never a wall-clock timestamp.
+  web-container version counter works — never a wall-clock timestamp. A
+  timestamp lands near `u32::MAX`, and `MAX_POINTER_VERSION` is `u32::MAX - 1`
+  precisely because a record at the ceiling could never be superseded.
+- **Re-read the pointer after publishing and confirm the version and code hash
+  are the ones you meant.** A publish at an already-used version is a silent
+  no-op *success* — the contract deliberately does not error on a stale update,
+  because that would turn ordinary anti-entropy from a behind peer into a merge
+  failure. The network will never tell you your release was ignored.
+- **If you lose the counter's store, recover the version from the network, and
+  only from a record that verifies under your own key.** A counter that restarts
+  makes every later publish a no-op success, freezing the pointer at a
+  generation you are no longer writing to. Adopting an *unverified* read-back is
+  the opposite failure and is worse: nobody else can move your pointer, since
+  only your key signs a record the contract accepts, so a peer that answers with
+  a forged high version simply gets **you** to sign the next one just below the
+  unsupersedable ceiling. Monotonicity means you cannot walk it back down.
 - **PUT the committed, published WASM artifact; never a local rebuild.** A local
   rebuild puts your pointer at an address nobody else derives: invisible to every
   consumer, and indistinguishable from success on your side.

--- a/skills/dapp-builder/references/facade-pattern.md
+++ b/skills/dapp-builder/references/facade-pattern.md
@@ -294,6 +294,11 @@ Failure here is a release blocker. Possible causes:
 3. **A workspace dep leaked in** because the facade isn't actually in
    `[workspace.exclude]` or doesn't have its own `Cargo.lock`. See
    `build-system.md` → "Per-contract lockfile isolation".
+4. **The build embedded a machine-specific path, or reused a stale
+   `target/`.** Both move the bytes without any source change, and both
+   make the snapshot reproducible only on the host that produced it —
+   which looks exactly like a real drift. Check these before concluding
+   a dependency moved: `build-system.md` → "Byte-reproducibility".
 
 ### Regenerating the facade snapshot from a non-Linux host
 

--- a/skills/dapp-builder/references/identity-and-addressing.md
+++ b/skills/dapp-builder/references/identity-and-addressing.md
@@ -595,7 +595,9 @@ the delegate build was not reproducible, so the key depended on which machine
 built it (fixed, #9). Both are closed, but the shape of the risk is permanent
 for any delegate: if you build one, keep an equivalent registry and treat
 "which bytes does this source produce" as a correctness property. See
-`upgrade-and-migration.md`.
+`upgrade-and-migration.md`. The mechanics — which
+roots to remap, and the fail-closed check that refuses a machine-specific build —
+are under "Byte-reproducibility" in `build-system.md`.
 
 That is true of most of the Freenet stack right now, and it is a reason to
 price the risk in rather than a reason to avoid it. The concrete recourse when

--- a/skills/dapp-builder/references/ui-patterns.md
+++ b/skills/dapp-builder/references/ui-patterns.md
@@ -927,7 +927,10 @@ key=$(fdev publish --code ... delegate 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | grep -
 # 2. Decode base58 → JSON byte array (requires bs58 npm package)
 node -e "const bs58=require('bs58');console.log(JSON.stringify(Array.from(bs58.default.decode('$key'))))" > delegate_key_bytes.json
 
-# 3. Compute code_hash from raw WASM (BLAKE3)
+# 3. Compute code_hash from raw WASM (BLAKE3).
+#    Build this through the project's canonical build script into a throwaway
+#    target dir -- a reused target/ can silently change the bytes, and this hash
+#    is compiled into the UI. See build-system.md -> "Byte-reproducibility".
 code_hash_hex=$(b3sum --no-names target/wasm32-unknown-unknown/release/my_delegate.wasm)
 node -e "const h='$code_hash_hex'.trim();console.log(JSON.stringify(Array.from(Buffer.from(h,'hex'))))" > delegate_code_hash_bytes.json
 ```

--- a/skills/dapp-builder/references/upgrade-and-migration.md
+++ b/skills/dapp-builder/references/upgrade-and-migration.md
@@ -83,8 +83,14 @@ The whole procedure, start to finish:
    Commit `Cargo.lock`, pin the toolchain (`rust-toolchain.toml`), build
    `--locked`. Otherwise a stray `cargo update` or a different rustc silently
    re-keys the contract and orphans data with no upgrade in sight (River's
-   `Cargo.lock` was gitignored — freenet/river#393). See `build-system.md` →
-   "Byte-reproducibility" and "Hash + artifact hygiene" below.
+   `Cargo.lock` was gitignored — freenet/river#393).
+
+   **Those three are the minimum, not the whole job.** They do not stop the
+   build machine's absolute paths being compiled into the WASM (which binds the
+   contract to whoever built it) or a stale `target/` changing the bytes. Build
+   through one canonical script that remaps `CARGO_HOME`, `RUSTUP_HOME` and the
+   repo root and refuses if a build-machine path survives. See `build-system.md`
+   → "Byte-reproducibility" and "Hash + artifact hygiene" below.
 
 3. **BEFORE you change the WASM, register the *outgoing* code hash in the legacy
    registry.** This is the one required operational step and the single most


### PR DESCRIPTION
Field findings from a night of building and deploying a Freenet app. Every claim
was verified against primary sources before writing — `freenet-migrate` 0.6.0's
`src/pointer.rs`, the pointer contract's own source and README, and
`freenet-bitcoin/scripts/build-contracts.sh` — and several of the findings as
originally stated turned out to need correcting.

## Corrections to existing text

**The baked-in fallback was licensed on `Unavailable`.** The opening call-out of
`building-on-other-apps.md` said a resolve returning `NeverPublished` *or*
`Unavailable` meant "the baked-in fallback is legitimately what you use". That
contradicted the same file's outcome table, its own "true for `NeverPublished` and
nothing else" line, and `PointerOutcome::may_use_baked_in_fallback`, which is
`matches!(self, Self::NeverPublished)`. Treating "could not reach it" as "it does
not exist" is a free downgrade for anyone able to drop a GET, and the wrong
sentence was above the fold, aimed at first-run readers.

**`-Ctrim-paths` does not exist.** It was offered as an equivalent alternative to
`--remap-path-prefix`. Verified by running it: `rustc -Ctrim-paths=all` is an
"unknown codegen option", and Cargo's `trim-paths = "all"` profile setting is
still unstable on Rust 1.96.0, which the exemplar project pins.

**The canonical `Makefile.toml` example** built the contract and the delegate in
two separate bare `cargo build -p` invocations — at once the feature-unification
footgun the same file warns about three sections later, and an unremapped build.

**The CI `wasm-staleness` sample** used a bare `cargo build`, which under the new
doctrine would fail on the runner's own paths.

## New material

- **Remapping your own source path is not enough.** Release binaries embed panic
  locations as `file:line` and cargo passes absolute paths for dependencies, so
  the cargo registry root lands in the WASM — measured at 21 occurrences across
  fourteen crate roots in one contract. Since the address is
  `BLAKE3(BLAKE3(wasm) ‖ params)`, every contract built was bound to its build
  machine, and a runner and a dev box produced different contracts from one
  commit. `CARGO_HOME` and `RUSTUP_HOME` must be remapped too, the replacement
  names become part of the contract's identity, and the check must be fail-closed.
- **A stale `target/` silently changes contract identity**, and `cargo clean -p`
  on workspace crates does not fix it: dependency artifacts are reused and under
  fat LTO yield a different module.
- **The pointer's I/O seam.** `PointerFetch` is three-way for the same reason
  `ProbeAnswer` is — a two-way `Option` transport can never reach
  `NeverPublished` and so silently deletes its own fallback. A pointer GET must
  not request the contract code (100 bytes of answer against ~130 KB of WASM),
  which is why `PointerIo` exists separately from `ProbeIo`.
- **Author-side publishing.** A publish at an already-used version is a silent
  no-op *success* (verified in the contract source, not just prose), so re-read
  the pointer afterwards. Recovering a lost version counter is safe only from a
  record that verifies under your own key: nobody else can move your pointer, so
  an unverified read-back gets *you* to sign near the reserved ceiling.
- **`SuccessorPointer`** named as the fourth pointer-like thing, with its own
  signing domain.

Migration doctrine itself went to the owner skill, `freenet-app-migration`
(pushed separately to `sanity/claude-config`), which had zero mentions of
`freenet_migrate::pointer` before this.

## Review

Two independent adversarial reviews ran against the first commit: a fact-check of
every claim against primary sources, and a consistency sweep of the whole skill
corpus for the "doctrine changed here, the worked example still teaches the old
thing" failure. Both found real defects, fixed in `cc88337` — including three
errors in my own new text (a miscounted registry-root figure, an overstated
wall-clock-timestamp claim, and attributing the throwaway target dir to the build
script rather than to its callers).

One upstream issue worth filing separately: `resolve_app_pointer`'s rustdoc in
freenet-migrate 0.6.0 still says `NeverPublished` is "unreachable by construction"
through `ConservativeProbeIo`. That is stale 0.5-era prose — the 0.6.0 impl maps
`ProbeAnswer::Absent → PointerFetch::Absent` and a test pins it. These docs do not
repeat the stale claim.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop
